### PR TITLE
Bugfix: Changed CurrentTemperature min/max values

### DIFF
--- a/pyhap/resources/characteristics.json
+++ b/pyhap/resources/characteristics.json
@@ -303,9 +303,9 @@
          "ev"
       ],
       "unit": "celsius",
-      "minValue": 0,
+      "minValue": -273.1,
       "minStep": 0.1,
-      "maxValue": 100
+      "maxValue": 1000
    },
    "CurrentTime": {
       "Format": "string",


### PR DESCRIPTION
I noticed that the min value for `CurrentTemperature` was set to `0` which doesn't account for negative temperatures.

I really like your project. After I saw the discussion in the `HomeAssistant` Forum about implementing `Homekit` support, I tried a few things with your project myself 👍