### PR TITLE
Dynamic codes

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO)
 
 def get_bridge():
     """Call this method to get a Bridge instead of a standalone accessory."""
-    bridge = Bridge(display_name="Bridge", pincode=b"203-23-999")
+    bridge = Bridge(display_name="Bridge")
     temp_sensor = TemperatureSensor("Termometer")
     temp_sensor2 = TemperatureSensor("Termometer2")
     bridge.add_accessory(temp_sensor)
@@ -29,10 +29,11 @@ def get_bridge():
     # bridge.add_accessory(bulb)
     return bridge
 
+
 def get_accessory():
     """Call this method to get a standalone Accessory."""
-    acc = TemperatureSensor("MyTempSensor",
-                            pincode=b"203-23-999")
+    acc = TemperatureSensor("MyTempSensor")
+    print(acc.pincode)  # Until we get QR code merged.
     return acc
 
 

--- a/pyhap/util.py
+++ b/pyhap/util.py
@@ -1,11 +1,9 @@
 import socket
-import os
 import random
 import binascii
 import sys
 
 
-DIGITS = '0123456789'
 ALPHANUM = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 HEX_DIGITS = '0123456789ABCDEF'
 
@@ -38,8 +36,7 @@ def long_to_bytes(n):
 
 def generate_mac():
     return "{}{}:{}{}:{}{}:{}{}:{}{}:{}{}".format(
-        *str(binascii.hexlify(os.urandom(6)), "utf-8").upper())
-        # *(rand.choice(HEX_DIGITS) for _ in range(12)))
+        *(rand.choice(HEX_DIGITS) for _ in range(12)))
 
 
 def generate_setup_id():

--- a/pyhap/util.py
+++ b/pyhap/util.py
@@ -1,7 +1,15 @@
 import socket
 import os
+import random
 import binascii
 import sys
+
+
+DIGITS = '0123456789'
+ALPHANUM = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+HEX_DIGITS = '0123456789ABCDEF'
+
+rand = random.SystemRandom()
 
 
 def get_local_address():
@@ -30,7 +38,21 @@ def long_to_bytes(n):
 
 def generate_mac():
     return "{}{}:{}{}:{}{}:{}{}:{}{}:{}{}".format(
-               *str(binascii.hexlify(os.urandom(6)), "utf-8").upper())
+        *str(binascii.hexlify(os.urandom(6)), "utf-8").upper())
+        # *(rand.choice(HEX_DIGITS) for _ in range(12)))
+
+
+def generate_setup_id():
+    return ''.join([
+        rand.choice(ALPHANUM)
+        for i in range(4)
+    ])
+
+
+def generate_pincode():
+    return '{}{}{}-{}{}-{}{}{}'.format(
+        *(rand.randint(0, 9) for i in range(8))
+    ).encode('ascii')
 
 
 def b2hex(bts):
@@ -40,6 +62,7 @@ def b2hex(bts):
     @rtype: string
     """
     return binascii.hexlify(bts).decode("ascii")
+
 
 def hex2b(hex):
     """Produce bytes from the given hex string representation.

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,7 @@ envlist = py35,py36
 [testenv]
 deps = pytest
 commands = pytest
+
+[testenv:temperature]
+basepython= python3.6
+commands = python main.py


### PR DESCRIPTION
Generate random `pincode` and `setup_id` each time the process is restarted (unless explicitly passed in).

This is in line with the recommendations from the Apple HAP documentation: https://developer.apple.com/support/homekit-accessory-protocol/