### PR TITLE
Char: Set default for 'valid_value' to 0

### DIFF
--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -34,6 +34,7 @@ class HAP_FORMAT:
         UINT64: 0,
         DATA: "",
         TLV8: "",
+        'VALID_VALUES': 0,
     }
 
 

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -34,7 +34,6 @@ class HAP_FORMAT:
         UINT64: 0,
         DATA: "",
         TLV8: "",
-        'VALID_VALUES': 0,
     }
 
 
@@ -107,7 +106,7 @@ class Characteristic(object):
             self.value = value
         else:
             if self.properties.get('ValidValues'):
-                self.value = next(iter(self.properties["ValidValues"].values()))
+                self.value = min(self.properties['ValidValues'].values())
             else:
                 self.value = HAP_FORMAT.DEFAULT[properties["Format"]]
         self.broker = broker


### PR DESCRIPTION
A `valid_value` set to 0 makes testing easier. Before the `next` function could return any of the values, since (at least for py35) `dict.values` doesn't necessarily returns a sorted list.

The value `0` is set for all characteristics that have the attribute `validValues` so it shouldn't be an issue.