### PR TITLE
Acc Driver: Should_notify

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -440,7 +440,7 @@ class AccessoryDriver(object):
             }
             if "value" in cq:
                 # TODO: status needs to be based on success of set_value
-                char.set_value(cq["value"], should_notify=False)
+                char.set_value(cq["value"], should_notify=True)
                 if "r" in cq:
                     response["value"] = char.value
 


### PR DESCRIPTION
I recently came across an issue on the Home Assistant Github page: https://github.com/home-assistant/home-assistant/issues/13345

A user has two iPads and if he executes a command on one the state doesn't change on the second one. I believe that can be fixed with setting `should_notify=True` in the `set_characteristics` method of `accessory_driver`. However I don't know if there are any reasons why you choose to set it in the first place.