### PR TITLE
Remove opt_chars and get_value

### DIFF
--- a/pyhap/accessories/FakeFan.py
+++ b/pyhap/accessories/FakeFan.py
@@ -28,12 +28,12 @@ class FakeFan(Accessory):
 
         # Add the optional RotationSpeed characteristic to the Fan
         rotation_speed_char = loader.get_char_loader().get("RotationSpeed")
-        fan_service.add_opt_characteristic(rotation_speed_char)
+        fan_service.add_characteristic(rotation_speed_char)
         rotation_speed_char.setter_callback = self.set_rotation_speed
 
         # Add the optional RotationSpeed characteristic to the Fan
         rotation_dir_char = loader.get_char_loader().get("RotationDirection")
-        fan_service.add_opt_characteristic(rotation_dir_char)
+        fan_service.add_characteristic(rotation_dir_char)
         rotation_dir_char.setter_callback = self.set_rotation_direction
 
         self.add_service(fan_service)

--- a/pyhap/accessories/Http.py
+++ b/pyhap/accessories/Http.py
@@ -108,7 +108,7 @@ class HttpBridge(Bridge):
     >>> # Also, add an optional characteristic Name to the service.
     >>> temperature_acc_2 = Accessory("temp2")
     >>> temp_service = service_loader.get("TemperatureSensor")
-    >>> temp_service.add_opt_characteristic(char_loader.get("StatusLowBattery"))
+    >>> temp_service.add_characteristic(char_loader.get("StatusLowBattery"))
     >>> temperature_acc_2.add_service(temp_service)
     >>>
     >>> # Create a lightbulb accessory.

--- a/pyhap/accessories/SDS011.py
+++ b/pyhap/accessories/SDS011.py
@@ -78,7 +78,7 @@ class SDS011(Accessory):
         pm25_name = char_loader.get("Name")
         pm25_name.set_value("PM2.5", should_notify=False)
         self.pm25_quality = air_quality_pm25.get_characteristic("AirQuality")
-        air_quality_pm25.add_opt_characteristic(pm25_name, pm25_size, self.pm25_density)
+        air_quality_pm25.add_characteristic(pm25_name, pm25_size, self.pm25_density)
 
         # PM10
         air_quality_pm10 = loader.get_serv_loader().get("AirQualitySensor")
@@ -88,7 +88,7 @@ class SDS011(Accessory):
         pm10_name = char_loader.get("Name")
         pm10_name.set_value("PM10", should_notify=False)
         self.pm10_quality = air_quality_pm10.get_characteristic("AirQuality")
-        air_quality_pm10.add_opt_characteristic(pm10_name, pm10_size, self.pm10_density)
+        air_quality_pm10.add_characteristic(pm10_name, pm10_size, self.pm10_density)
 
         self.add_service(air_quality_pm25)
         self.add_service(air_quality_pm10)

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -256,7 +256,7 @@ class Accessory(object):
         for s in servs:
             self.services.append(s)
             self.iid_manager.assign(s)
-            for c in s.characteristics + s.opt_characteristics:
+            for c in s.characteristics:
                 self.iid_manager.assign(c)
                 c.broker = self
 

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -382,7 +382,7 @@ class AccessoryDriver(object):
             rep = {"aid": aid, "iid": iid}
             char = self.accessory.get_characteristic(aid, iid)
             try:
-                rep["value"] = char.get_value()
+                rep["value"] = char.value
                 rep["status"] = HAP_CONSTANTS.CHAR_STAT_OK
             except CharacteristicError:
                 logger.error("Error getting value for characteristic %s.", id)

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -146,13 +146,6 @@ class Characteristic(object):
         if should_notify and self.broker is not None:
             self.notify()
 
-    def get_value(self):
-        """Get the raw value of this Characteristic.
-
-        .. deprecated:: v1.1.0 Use self.value instead.
-        """
-        return self.value
-
     def override_properties(self, properties=None, valid_values=None):
         """Override characteristic property values and valid values.
 

--- a/pyhap/service.py
+++ b/pyhap/service.py
@@ -40,13 +40,15 @@ class Service(object):
         :param name: The name of the characteristic to search for.
         :type name: str
 
-        :return: A characteristic with the given name or None if not found.
+        :raise ValueError if characteristic is not found.
+
+        :return: A characteristic with the given name.
         :rtype: Characteristic
         """
-        char = next((c for c in self.characteristics if c.display_name == name),
-                    None)
-        assert char is not None
-        return char
+        for char in self.characteristics:
+            if char.display_name == name:
+                return char
+        raise ValueError('Characteristic not found')
 
     def to_HAP(self, iid_manager=None):
         """Create a HAP representation of this Service.

--- a/pyhap/service.py
+++ b/pyhap/service.py
@@ -4,35 +4,25 @@
 class Service(object):
     """A representation of a HAP service.
 
-    A Service contains multiple characteristics. For example, a TemperatureSensor service
-    has the characteristic CurrentTemperature.
+    A Service contains multiple characteristics. For example, a
+    TemperatureSensor service has the characteristic CurrentTemperature.
 
-    For the services that iOS natively supports, we distinguish two types of
-    characteristics - (1) "mandatory", which must be present when communicating with an
-    iOS client, and (2) optional, which may or may not be present. All mandatory and
-    optional characteristics for iOS-supported services are defined in the
-    resources/services.json file. When you load a service using the loader module, only
-    the mandatory characteristics are added - you need to add any optional characteristics
-    yourself. This is because once a characteristic is present, iOS will want values for
-    it and we need to know how to set these.
+    When you load a service using the loader module, only the required
+    characteristics are added - you need to add any optional characteristics
+    yourself. This is because once a characteristic is present, iOS will want
+    values for it and we need to know how to set these.
     """
     def __init__(self, type_id, display_name=None):
         self.display_name = display_name
         self.type_id = type_id
         self.characteristics = []
-        self.opt_characteristics = []
         # TODO: name characteristic
 
     def __repr__(self):
         """Return the representation of the service."""
-        chars = {}
-        opt_chars = {}
-        for c in self.characteristics:
-            chars[c.display_name] = c.value
-        for c in self.opt_characteristics:
-            opt_chars[c.display_name] = c.value
-        return "<service display_name='{}' chars={} opt_chars={}>" \
-            .format(self.display_name, chars, opt_chars)
+        return "<service display_name='{}' chars={}>" \
+            .format(self.display_name,
+                    {c.display_name: c.value for c in self.characteristics})
 
     def _add_chars(self, container, *chars):
         """Helper method to add the given characteristics to the given container."""
@@ -44,29 +34,17 @@ class Service(object):
         """Add the given characteristics as "mandatory" for this Service."""
         self._add_chars(self.characteristics, *chars)
 
-    def add_opt_characteristic(self, *chars):
-        """Add the given characteristics as optional for this Service."""
-        self._add_chars(self.opt_characteristics, *chars)
-
-    def get_characteristic(self, name, check_optional=True):
+    def get_characteristic(self, name):
         """Return a Characteristic object by the given name from this Service.
-
-        Checks only the mandatory characteristics by default.
 
         :param name: The name of the characteristic to search for.
         :type name: str
-
-        :param check_optional: Whether to search in the optional characteristics as well.
-        :type check_optional: bool
 
         :return: A characteristic with the given name or None if not found.
         :rtype: Characteristic
         """
         char = next((c for c in self.characteristics if c.display_name == name),
                     None)
-        if char is None and check_optional:
-            char = next((c for c in self.opt_characteristics if c.display_name == name),
-                        None)
         assert char is not None
         return char
 
@@ -80,8 +58,7 @@ class Service(object):
         :rtype: dict.
         """
         assert iid_manager is not None
-        characteristics = [c.to_HAP(iid_manager)
-                           for c in self.characteristics + self.opt_characteristics]
+        characteristics = [c.to_HAP(iid_manager) for c in self.characteristics]
 
         hap_rep = {
             "iid": iid_manager.get_iid(self),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -23,14 +23,7 @@ def test_add_characteristic():
     chars = get_chars()
     serv.add_characteristic(*chars)
     for c in chars:
-        assert serv.get_characteristic(c.display_name, check_optional=False) == c
-
-def test_add_opt_characteristic():
-    serv = service.Service(uuid.uuid1(), "Test Service")
-    chars = get_chars()
-    serv.add_opt_characteristic(*chars)
-    for c in chars:
-        assert serv.get_characteristic(c.display_name, check_optional=True) == c
+        assert serv.get_characteristic(c.display_name) == c
 
 def test_to_HAP():
     pass # TODO:


### PR DESCRIPTION
A bit cleanup.
Removed:
* opt_characteristics (service)
* add_opt_characteristics (service)
* get_value (chars)

## Breaking changes:
* Removed `add_opt_characteristic`. There is no further distinction between optional and require chars during execution. All chars that have been added as `optional` should now simply use `add_characteristic`. (The loader hasn't changed.)
* The method `get_characteristic` now raises a `ValueError` if the characteristic isn't found
* The already deprecated method `get_value` was removed. Use `char.value` instead.