### PR TITLE
Fix for overriding properties

### DIFF
--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -144,6 +144,12 @@ class Characteristic:
         if valid_values:
             self.properties['ValidValues'] = valid_values
 
+        if properties or valid_values:
+            try:
+                self.value = self.to_valid_value(self.value)
+            except ValueError:
+                self.value = self._get_default_value()
+
     def set_value(self, value, should_notify=True):
         """Set the given raw value. It is checked if it is a valid value.
 


### PR DESCRIPTION
If properties are overridden, we should make sure that we still have a valid value. If not, getting a new default value seems to be a good idea, since `overriding` usually happens in the `__init__` call for an accessory.