### PR TITLE
Updated tests, bugfixes

### DIFF
--- a/docs/source/api/characteristic.rst
+++ b/docs/source/api/characteristic.rst
@@ -10,11 +10,3 @@ Characteristic Base class for a HAP Accessory ``Service``.
 
 .. autoclass:: pyhap.characteristic.Characteristic
    :members:
-
-
-CharLoader
-==========
-
-Useful for loading ``Characteristic`` for a ``Service``.
-
-.. autoclass:: pyhap.loader.CharLoader

--- a/docs/source/api/loader.rst
+++ b/docs/source/api/loader.rst
@@ -1,0 +1,10 @@
+.. _api-loader:
+
+======
+Loader
+======
+
+Useful for creating a ``Service`` or ``Characteristic``.
+
+.. autoclass:: pyhap.loader.TypeLoader
+	:members:

--- a/docs/source/api/service.rst
+++ b/docs/source/api/service.rst
@@ -8,12 +8,3 @@ Service Base class for a HAP ``Accessory``.
 
 .. autoclass:: pyhap.service.Service
    :members:
-
-
-ServiceLoader
-=============
-
-Useful for creating a ``Service``.
-
-.. autoclass:: pyhap.loader.ServiceLoader
-   :members:

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -176,7 +176,7 @@ class Accessory(object):
             always call the base implementation first, as it reserves IID of
             1 for the Accessory Information service (HAP requirement).
         """
-        info_service = get_serv_loader().get("AccessoryInformation")
+        info_service = get_serv_loader().get_service("AccessoryInformation")
         info_service.get_characteristic("Name")\
                     .set_value(self.display_name, False)
         info_service.get_characteristic("Manufacturer")\

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -147,17 +147,20 @@ class Characteristic:
             valid_values. Valid values will be set to new dictionary.
         :type valid_values: dict
         """
+        if not properties and not valid_values:
+            raise ValueError(
+                'No properties or valid_values specified to override.')
+
         if properties:
             self.properties.update(properties)
 
         if valid_values:
             self.properties[PROP_VALID_VALUES] = valid_values
 
-        if properties or valid_values:
-            try:
-                self.value = self.to_valid_value(self.value)
-            except ValueError:
-                self.value = self._get_default_value()
+        try:
+            self.value = self.to_valid_value(self.value)
+        except ValueError:
+            self.value = self._get_default_value()
 
     def set_value(self, value, should_notify=True):
         """Set the given raw value. It is checked if it is a valid value.

--- a/pyhap/service.py
+++ b/pyhap/service.py
@@ -22,7 +22,7 @@ class Service:
 
     def __repr__(self):
         """Return the representation of the service."""
-        return "<service display_name='{}' chars={}>" \
+        return '<service display_name={} chars={}>' \
             .format(self.display_name,
                     {c.display_name: c.value for c in self.characteristics})
 
@@ -49,12 +49,12 @@ class Service:
                 return char
         raise ValueError('Characteristic not found')
 
-    def configure_char(char_name, properties=None, valid_values=None,
+    def configure_char(self, char_name, properties=None, valid_values=None,
                        value=None, setter_callback=None):
         """Helper method to return fully configured characteristic."""
-        char = service.get_characteristic(char_name)
+        char = self.get_characteristic(char_name)
         if properties or valid_values:
-            char.override_properties(properties)
+            char.override_properties(properties, valid_values)
         if value:
             char.set_value(value, should_notify=False)
         if setter_callback:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+pytest-timeout>=1.2.1

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -13,7 +13,7 @@ class TestAccessory(object):
 
     def test_publish_no_broker(self):
         acc = accessory.Accessory("Test Accessory")
-        service = loader.get_serv_loader().get("TemperatureSensor")
+        service = loader.get_serv_loader().get_service("TemperatureSensor")
         char = service.get_characteristic("CurrentTemperature")
         acc.add_service(service)
         char.set_value(25, should_notify=True)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,41 +1,87 @@
-"""
-Tests for pyhap.loader
-"""
+"""Tests for pyhap.loader."""
+from unittest.mock import patch, ANY, Mock
+
 import pytest
-from unittest import mock
 
 from pyhap import CHARACTERISTICS_FILE, SERVICES_FILE
-import pyhap.loader as loader
+from pyhap.characteristic import Characteristic
+from pyhap.service import Service
+from pyhap.loader import get_char_loader, get_serv_loader, TypeLoader
 
-# CharLoader
 
-def test_custom_char_class_init():
+def test_loader_char():
+    with open(CHARACTERISTICS_FILE, 'r') as file:
+        loader = TypeLoader(file)
+    assert loader.types is not None
 
-    mock_char = mock.Mock(side_effect=mock.Mock())
-    with open(CHARACTERISTICS_FILE, "r") as fp:
-        ldr = loader.CharLoader(fp, char_class=mock_char)
-    char = ldr.get("CurrentTemperature")
-    assert isinstance(char, mock.Mock)
+    assert loader.get('Name') is not None
+    with pytest.raises(KeyError):
+        loader.get('Not a char')
 
-def test_custom_char_class_get():
-    mock_char = mock.Mock(side_effect=mock.Mock())
-    with open(CHARACTERISTICS_FILE, "r") as fp:
-        ldr = loader.CharLoader(fp)
-    char = ldr.get("CurrentTemperature", char_class=mock_char)
-    assert isinstance(char, mock.Mock)
+    assert isinstance(loader.get_char('Name'), Characteristic)
 
-# ServiceLoader
 
-def test_custom_service_class_init():
-    mock_class = mock.Mock(side_effect=mock.Mock())
-    with open(SERVICES_FILE, "r") as fp:
-        ldr = loader.ServiceLoader(fp, service_class=mock_class)
-    service = ldr.get("TemperatureSensor")
-    assert isinstance(service, mock.Mock)
+def test_loader_get_char_error():
+    loader = TypeLoader.__new__(TypeLoader)
+    loader.types = {'Char': None}
+    json_dicts = (
+        {'Format': 'int', 'Permissions': 'read'},
+        {'Format': 'int', 'UUID': '123456'},
+        {'Permissions': 'read', 'UUID': '123456'}
+    )
 
-def test_custom_service_class_get():
-    mock_class = mock.Mock(side_effect=mock.Mock())
-    with open(SERVICES_FILE, "r") as fp:
-        ldr = loader.ServiceLoader(fp)
-    service = ldr.get("TemperatureSensor", service_class=mock_class)
-    assert isinstance(service, mock.Mock)
+    for case in json_dicts:
+        loader.types['Char'] = case
+        with pytest.raises(KeyError):
+            loader.get_char('Char')
+
+
+def test_loader_service():
+    with open(SERVICES_FILE, 'r') as file:
+        loader = TypeLoader(file)
+    assert loader.types is not None
+
+    assert loader.get('AccessoryInformation') is not None
+    with pytest.raises(KeyError):
+        loader.get('Not a service')
+
+    with patch('pyhap.service.Service.from_dict') as mock_service_from_dict:
+        service = loader.get_service('AccessoryInformation', Mock())
+        mock_service_from_dict.assert_called_with(
+            'AccessoryInformation', loader.get('AccessoryInformation'), ANY)
+
+
+def test_loader_service_error():
+    loader = TypeLoader.__new__(TypeLoader)
+    loader.types = {'Service': None}
+    json_dicts = (
+        {'RequiredCharacteristics': ['Char 1', 'Char 2']},
+        {'UUID': '123456'}
+    )
+
+    for case in json_dicts:
+        loader.types['Service'] = case
+        with pytest.raises(KeyError):
+            loader.get_service('Service')
+
+
+def test_get_char_loader():
+    char_loader = get_char_loader()
+    assert isinstance(char_loader, TypeLoader)
+
+    with open(CHARACTERISTICS_FILE, 'r') as file:
+        loader = TypeLoader(file)
+    assert char_loader.types == loader.types
+
+    assert get_char_loader() == char_loader
+
+
+def test_get_serv_loader():
+    serv_loader = get_serv_loader()
+    assert isinstance(serv_loader, TypeLoader)
+
+    with open(SERVICES_FILE, 'r') as file:
+        loader = TypeLoader(file)
+    assert serv_loader.types == loader.types
+
+    assert get_serv_loader() == serv_loader

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,29 +1,131 @@
-"""
-Tests for pyhap.service
-"""
-import uuid
+"""Tests for pyhap.service."""
+from uuid import uuid1, UUID
+from unittest.mock import call, patch, Mock
 
 import pytest
 
-import pyhap.service as service
-from pyhap.characteristic import Characteristic, HAP_FORMAT, HAP_PERMISSIONS
+from pyhap.service import Service
+from pyhap.characteristic import (
+    Characteristic, HAP_FORMAT_INT, HAP_PERMISSION_READ,
+    PROP_FORMAT, PROP_PERMISSIONS)
 
 CHAR_PROPS = {
-    "Format": HAP_FORMAT.INT,
-    "Permissions": HAP_PERMISSIONS.READ,
+    PROP_FORMAT: HAP_FORMAT_INT,
+    PROP_PERMISSIONS: HAP_PERMISSION_READ,
 }
 
 def get_chars():
-    c1 = Characteristic("Char 1", uuid.uuid1(), CHAR_PROPS)
-    c2 = Characteristic("Char 2", uuid.uuid1(), CHAR_PROPS)
+    c1 = Characteristic('Char 1', uuid1(), CHAR_PROPS)
+    c2 = Characteristic('Char 2', uuid1(), CHAR_PROPS)
     return [c1, c2]
 
+
+def test_repr():
+    service = Service(uuid1(), 'TestService')
+    service.characteristics = [get_chars()[0]]
+    assert service.__repr__() == \
+        "<service display_name=TestService chars={'Char 1': 0}>"
+
+
 def test_add_characteristic():
-    serv = service.Service(uuid.uuid1(), "Test Service")
+    service = Service(uuid1(), 'Test Service')
     chars = get_chars()
-    serv.add_characteristic(*chars)
-    for c in chars:
-        assert serv.get_characteristic(c.display_name) == c
+    service.add_characteristic(*chars)
+    for char_service, char_original in zip(service.characteristics, chars):
+        assert char_service == char_original
+
+    service.add_characteristic(chars[0])
+    assert len(service.characteristics) == 2
+
+
+def test_get_characteristic():
+    service = Service(uuid1(), 'Test Service')
+    chars = get_chars()
+    service.characteristics = chars
+    assert service.get_characteristic('Char 1') == chars[0]
+    with pytest.raises(ValueError):
+        service.get_characteristic('Not found')
+
+
+def test_configure_char():
+    pyhap_char = 'pyhap.characteristic.Characteristic'
+
+    service = Service(uuid1(), 'Test Service')
+    chars = get_chars()
+    service.characteristics = chars
+
+    with pytest.raises(ValueError):
+        service.configure_char('Char not found')
+    assert service.configure_char('Char 1') == chars[0]
+
+    with patch(pyhap_char + '.override_properties') as mock_override_prop, \
+            patch(pyhap_char + '.set_value') as mock_set_value:
+        service.configure_char('Char 1')
+        mock_override_prop.assert_not_called()
+        mock_set_value.assert_not_called()
+        assert service.get_characteristic('Char 1').setter_callback == None
+
+    with patch(pyhap_char + '.override_properties') as mock_override_prop:
+        new_properties = {'Format': 'string'}
+        new_valid_values = {0: 'on', 1: 'off'}
+        service.configure_char('Char 1', properties=new_properties)
+        mock_override_prop.assert_called_with(new_properties, None)
+        service.configure_char('Char 1', valid_values=new_valid_values)
+        mock_override_prop.assert_called_with(None, new_valid_values)
+        service.configure_char('Char 1', properties=new_properties,
+                               valid_values=new_valid_values)
+        mock_override_prop.assert_called_with(new_properties, new_valid_values)
+
+    with patch(pyhap_char + '.set_value') as mock_set_value:
+        new_value = 1
+        service.configure_char('Char 1', value=new_value)
+        mock_set_value.assert_called_with(1, should_notify=False)
+
+    new_setter_callback = 'Test callback'
+    service.configure_char('Char 1', setter_callback=new_setter_callback)
+    assert service.get_characteristic('Char 1').setter_callback == \
+        new_setter_callback
+
 
 def test_to_HAP():
-    pass # TODO:
+    uuid = uuid1()
+    pyhap_char_to_HAP = 'pyhap.characteristic.Characteristic.to_HAP'
+
+    service = Service(uuid, 'Test Service')
+    service.characteristics = get_chars()
+    with patch(pyhap_char_to_HAP) as mock_char_HAP, \
+            patch.object(service, 'broker') as mock_broker:
+        mock_iid = mock_broker.iid_manager.get_iid
+        mock_iid.return_value = 2
+        mock_char_HAP.side_effect = ('Char 1', 'Char 2')
+        hap_repr = service.to_HAP()
+        mock_iid.assert_called_with(service)
+    
+    assert hap_repr == {
+        'iid': 2,
+        'type': str(uuid).upper(),
+        'characteristics': ['Char 1', 'Char 2'],
+    }
+
+
+def test_from_dict():
+    uuid = uuid1()
+    chars = get_chars()
+    mock_char_loader = Mock()
+    mock_char_loader.get_char.side_effect = chars
+
+    json_dict = {
+        'UUID': str(uuid),
+        'RequiredCharacteristics': {
+            'Char 1',
+            'Char 2',
+        }
+    }
+
+    service = Service.from_dict('Test Service', json_dict, mock_char_loader)
+    assert service.display_name == 'Test Service'
+    assert service.type_id == uuid
+    assert service.characteristics == chars
+
+    mock_char_loader.get_char.assert_has_calls(
+        [call('Char 1'), call('Char 2')], any_order=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,docs
+envlist = py35, py36, docs
 skip_missing_interpreters = True
 
 [tox:travis]
@@ -9,7 +9,7 @@ skip_missing_interpreters = True
 [testenv]
 deps =
   -rtests/requirements.txt
-commands = pytest --cov=pyhap --cov-report= {posargs:pyhap tests}
+commands = pytest --timeout=3 --cov=pyhap --cov-report= {posargs:pyhap tests}
 
 [testenv:temperature]
 basepython = python3.6


### PR DESCRIPTION
Except for two tests in `accessory_driver` everything else should pass now. While I was updating the tests I found some bugs that are now fixed. Since the two failing tests block travis, I added `pytest-timeout` to the test dependencies and set `timeout=3`.

Changelog:
* Fixed Service.configure_char method
* Fixed Accessory._set_service
* Fixed Characteristic.override_properties
* Fixed docs
* New tests
* Added pytest-timeout