### PR TITLE
Fix aio_stop_event

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -158,7 +158,7 @@ class AccessoryDriver(object):
         self.topics = {}  # topic: set of (address, port) of subscribed clients
         self.topic_lock = threading.Lock()  # for exclusive access to the topics
         self.event_loop = asyncio.new_event_loop()
-        self.aio_stop_event = asyncio.Event()
+        self.aio_stop_event = asyncio.Event(loop=self.event_loop)
         self.stop_event = threading.Event()
         self.event_queue = queue.Queue()  # (topic, bytes)
         self.send_event_thread = None  # the event dispatch thread

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -50,8 +50,6 @@ def test_persist_load():
         os.remove(persist_file)
 
 
-@patch("pyhap.accessory_driver.asyncio.get_event_loop",
-       new=Mock(side_effect=asyncio.new_event_loop))
 @patch("pyhap.accessory_driver.Zeroconf", new=Mock())
 @patch("pyhap.accessory_driver.AccessoryDriver.persist")
 @patch("pyhap.accessory_driver.HAPServer", new=Mock())
@@ -59,26 +57,24 @@ def test_start_stop_sync_acc(_persist):
     class Acc(Accessory):
         running = True
         def run(self):
-            while self.run_sentinel.wait(2):
+            while self.run_sentinel.wait(0):
                 pass
             self.running = False
+            driver.stop()
         def setup_message(self): pass
 
     acc = Acc("TestAcc")
     driver = AccessoryDriver(acc, 51234, persist_file="foo")
     driver.start()
-    driver.stop()
     assert not acc.running
 
 
-#TODO: This test is failing when there is no patch for the get_event_loop.
-# Something is getting the default loop and not the new loop
 @patch("pyhap.accessory_driver.Zeroconf", new=Mock())
 @patch("pyhap.accessory_driver.AccessoryDriver.persist")
 @patch("pyhap.accessory_driver.HAPServer", new=Mock())
 def test_start_stop_async_acc(_persist):
     class Acc(AsyncAccessory):
-        @AsyncAccessory.run_at_interval(2)
+        @AsyncAccessory.run_at_interval(0)
         async def run(self):
             driver.stop()
         def setup_message(self): pass


### PR DESCRIPTION
In addition to #83, `asyncio.Event()` needs to be called with the `loop` parameter. Otherwise it throws an error when not executed in the main thread.