### PR TITLE
Improvements 4 - Service Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `driver.start` starts the event loop with `loop.run_forever()`. [#83](https://github.com/ikalchev/HAP-python/pull/83)
 - Debug logs for `char.set_value` and `char.client_update_value`. [#99](https://github.com/ikalchev/HAP-python/pull/99)
 - Changed default values associated with the `AccessoryInformation` service. [#102](https://github.com/ikalchev/HAP-python/pull/102)
+- `Accessory._set_services` is now deprecated. Instead services should be initialized in the accessories `init` method. [#102](https://github.com/ikalchev/HAP-python/pull/102)
 
 ### Fixed
 - Overriding properties now checks that value is still a valid value, otherwise value will be set to the default value. [#82](https://github.com/ikalchev/HAP-python/pull/82)
@@ -31,7 +32,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `Accessory.Category` class was removed and the `Category` constants moved to `pyhap/const.py` with the naming: `CATEGORY_[OLD_NAME]` (e.g. `CATEGORY_OTHER`) [#86](https://github.com/ikalchev/HAP-python/pull/86)
 - Updated `Accessories` to work with changes. [#74](https://github.com/ikalchev/HAP-python/pull/74), [#89](https://github.com/ikalchev/HAP-python/pull/89)
 - Renamed `Accessory.broker` to `Accessory.Driver`. `acc.set_broker` is now `acc.set_driver`. [#104](https://github.com/ikalchev/HAP-python/pull/104)
-- Removed accessory call to `Accessory._set_services`. Overriding this method not longer works. Instead services should be initialized in the accessories `init` method. [#102](https://github.com/ikalchev/HAP-python/pull/102)
 
 ### Developers
 - `to_HAP` methods don't require the `iid_manager` any more [#84](https://github.com/ikalchev/HAP-python/pull/84), [#85](https://github.com/ikalchev/HAP-python/pull/85)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - New helper methods to run the `run` method repeatedly, until the driver is stopped. `Accessory.repeat(time)` or `AsyncAccessory.repeat(time)`. [#74](https://github.com/ikalchev/HAP-python/pull/74)
 - New helper method `service.configure_char`. Shortcut to configuring a characteristic. [#84](https://github.com/ikalchev/HAP-python/pull/84)
 - Characteristics and Services can now be created from a json dictionary with `from_dict`. [#85](https://github.com/ikalchev/HAP-python/pull/85)
+- Added helper method to enable easy override of the `AccessoryInformation` service. [#102](https://github.com/ikalchev/HAP-python/pull/102)
+- Added helper method to load a service and chars and add it to an accessory. [#102](https://github.com/ikalchev/HAP-python/pull/102)
 
 ### Changed
 - Accessory.run method is now called through an event loop. You can either inherit from `Accessory` like before: The `run` method will be wrapped in a thread. Or inherit from `AsyncAccessory` and implement `async def run`. This will lead to the execution in the event loop. [#74](https://github.com/ikalchev/HAP-python/pull/74)
 - Scripts are now located in a separate directory: `scripts`. [#81](https://github.com/ikalchev/HAP-python/pull/81)
 - `driver.start` starts the event loop with `loop.run_forever()`. [#83](https://github.com/ikalchev/HAP-python/pull/83)
 - Debug logs for `char.set_value` and `char.client_update_value`. [#99](https://github.com/ikalchev/HAP-python/pull/99)
+- Changed default values associated with the `AccessoryInformation` service. [#102](https://github.com/ikalchev/HAP-python/pull/102)
 
 ### Fixed
 - Overriding properties now checks that value is still a valid value, otherwise value will be set to the default value. [#82](https://github.com/ikalchev/HAP-python/pull/82)
+- The `AccessoryInformation` service will always have the `iid=1`. [#102](https://github.com/ikalchev/HAP-python/pull/102)
 
 ### Breaking Changes
 - With introduction of async methods the min required Python version changes to `3.5`. [#74](https://github.com/ikalchev/HAP-python/pull/74)
 - The `Accessory.Category` class was removed and the `Category` constants moved to `pyhap/const.py` with the naming: `CATEGORY_[OLD_NAME]` (e.g. `CATEGORY_OTHER`) [#86](https://github.com/ikalchev/HAP-python/pull/86)
 - Updated `Accessories` to work with changes. [#74](https://github.com/ikalchev/HAP-python/pull/74), [#89](https://github.com/ikalchev/HAP-python/pull/89)
 - Renamed `Accessory.broker` to `Accessory.Driver`. `acc.set_broker` is now `acc.set_driver`. [#104](https://github.com/ikalchev/HAP-python/pull/104)
+- Removed accessory call to `Accessory._set_services`. Overriding this method not longer works. Instead services should be initialized in the accessories `init` method. [#102](https://github.com/ikalchev/HAP-python/pull/102)
 
 ### Developers
 - `to_HAP` methods don't require the `iid_manager` any more [#84](https://github.com/ikalchev/HAP-python/pull/84), [#85](https://github.com/ikalchev/HAP-python/pull/85)

--- a/main.py
+++ b/main.py
@@ -20,9 +20,9 @@ logging.basicConfig(level=logging.INFO)
 
 def get_bridge():
     """Call this method to get a Bridge instead of a standalone accessory."""
-    bridge = Bridge(display_name="Bridge")
-    temp_sensor = TemperatureSensor("Sensor 2")
-    temp_sensor2 = TemperatureSensor("Sensor 1")
+    bridge = Bridge(display_name='Bridge')
+    temp_sensor = TemperatureSensor('Sensor 2')
+    temp_sensor2 = TemperatureSensor('Sensor 1')
     bridge.add_accessory(temp_sensor)
     bridge.add_accessory(temp_sensor2)
 
@@ -35,7 +35,7 @@ def get_bridge():
 
 def get_accessory():
     """Call this method to get a standalone Accessory."""
-    acc = TemperatureSensor("MyTempSensor")
+    acc = TemperatureSensor('MyTempSensor')
     return acc
 
 

--- a/pyhap/accessories/AM2302.py
+++ b/pyhap/accessories/AM2302.py
@@ -12,7 +12,6 @@ import sensors.DHT22 as DHT22
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SENSOR
-import pyhap.loader as loader
 
 
 class AM2302(Accessory):
@@ -23,24 +22,18 @@ class AM2302(Accessory):
         super().__init__(*args, **kwargs)
         self.pin = pin
 
-        self.temp_char = self.get_service("TemperatureSensor")\
-                             .get_characteristic("CurrentTemperature")
+        serv_temp = self.add_preload_service('TemperatureSensor')
+        serv_humidity = self.add_preload_service('HumiditySensor')
 
-        self.humidity_char = self.get_service("HumiditySensor")\
-                                 .get_characteristic("CurrentRelativeHumidity")
+        self.char_temp = serv_temp.get_characteristic('CurrentTemperature')
+        self.char_humidity = serv_humidity \
+            .get_characteristic('CurrentRelativeHumidity')
 
         self.sensor = DHT22.sensor(pigpio.pi(), pin)
 
-    def _set_services(self):
-        super()._set_services()
-        self.add_service(
-            loader.get_serv_loader().get_service("TemperatureSensor"))
-        self.add_service(
-            loader.get_serv_loader().get_service("HumiditySensor"))
-
     def __getstate__(self):
         state = super().__getstate__()
-        state["sensor"] = None
+        state['sensor'] = None
         return state
 
     def __setstate__(self, state):
@@ -53,5 +46,5 @@ class AM2302(Accessory):
             time.sleep(0.2)
             t = self.sensor.temperature()
             h = self.sensor.humidity()
-            self.temp_char.set_value(t)
-            self.humidity_char.set_value(h)
+            self.char_temp.set_value(t)
+            self.char_humidity.set_value(h)

--- a/pyhap/accessories/BMP180.py
+++ b/pyhap/accessories/BMP180.py
@@ -5,7 +5,6 @@ from sensors.bmp180 import BMP180 as sensor
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SENSOR
-import pyhap.loader as loader
 
 
 class BMP180(Accessory):
@@ -15,19 +14,14 @@ class BMP180(Accessory):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.temp_char = self.get_service("TemperatureSensor")\
-                             .get_characteristic("CurrentTemperature")
+        serv_temp = self.add_preload_service('TemperatureSensor')
+        self.char_temp = serv_temp.get_characteristic('CurrentTemperature')
 
         self.sensor = sensor()
 
-    def _set_services(self):
-        super()._set_services()
-        self.add_service(
-            loader.get_serv_loader().get_service("TemperatureSensor"))
-
     def __getstate__(self):
         state = super().__getstate__()
-        state["sensor"] = None
+        state['sensor'] = None
         return state
 
     def __setstate__(self, state):
@@ -37,4 +31,4 @@ class BMP180(Accessory):
     def run(self):
         while not self.run_sentinel.wait(30):
             temp, _pressure = self.sensor.read()
-            self.temp_char.set_value(temp)
+            self.char_temp.set_value(temp)

--- a/pyhap/accessories/DisplaySwitch.py
+++ b/pyhap/accessories/DisplaySwitch.py
@@ -3,7 +3,6 @@ import subprocess
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SWITCH
-import pyhap.loader as loader
 
 
 def get_display_state():
@@ -29,14 +28,9 @@ class DisplaySwitch(Accessory):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.display = self.get_service("Switch")\
-                           .get_characteristic("On")
-        self.display.setter_callback = self.set_display
-
-    def _set_services(self):
-        super()._set_services()
-        self.add_service(
-            loader.get_serv_loader().get_service("Switch"))
+        serv_switch = self.add_preload_service('Switch')
+        self.display = serv_switch.configure_char(
+            'On', setter_callback=self.set_display)
 
     def run(self):
         while not self.run_sentinel.wait(1):

--- a/pyhap/accessories/FakeFan.py
+++ b/pyhap/accessories/FakeFan.py
@@ -3,7 +3,6 @@ import logging
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_FAN
-import pyhap.loader as loader
 
 logger = logging.getLogger(__name__)
 
@@ -13,29 +12,20 @@ class FakeFan(Accessory):
 
     category = CATEGORY_FAN
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        # Add the fan service. Also add optional characteristics to it.
+        serv_fan = self.add_preload_service(
+            'Fan', chars=['RotationSpeed', 'RotationDirection'])
+
+        self.char_rotation_speed = serv_fan.configure_char(
+            'RotationSpeed', setter_callback=self.set_rotation_speed)
+        self.char_rotation_direction = serv_fan.configure_char(
+            'RotationDirection', setter_callback=self.set_rotation_direction)
+
     def set_rotation_speed(self, value):
         logger.debug("Rotation speed changed: %s", value)
 
     def set_rotation_direction(self, value):
         logger.debug("Rotation direction changed: %s", value)
-
-    def _set_services(self):
-        """Add the fan service. Also add optional characteristics to it."""
-        super()._set_services()
-        fan_service = loader.get_serv_loader().get_service("Fan")
-        # NOTE: Don't forget that all characteristics must be added to the service before
-        # adding the service to the accessory, so that it can assign IIDs to all.
-
-        # Add the optional RotationSpeed characteristic to the Fan
-        rotation_speed_char = loader.get_char_loader() \
-            .get_char("RotationSpeed")
-        fan_service.add_characteristic(rotation_speed_char)
-        rotation_speed_char.setter_callback = self.set_rotation_speed
-
-        # Add the optional RotationSpeed characteristic to the Fan
-        rotation_dir_char = loader.get_char_loader() \
-            .get_char("RotationDirection")
-        fan_service.add_characteristic(rotation_dir_char)
-        rotation_dir_char.setter_callback = self.set_rotation_direction
-
-        self.add_service(fan_service)

--- a/pyhap/accessories/Http.py
+++ b/pyhap/accessories/Http.py
@@ -66,7 +66,7 @@ class HttpBridgeHandler(BaseHTTPRequestHandler):
         try:
             # The below decode is necessary only for python <3.6, because loads prior 3.6
             # doesn't know bytes/bytearray.
-            content = self.rfile.read(length).decode("utf-8")
+            content = self.rfile.read(length).decode('utf-8')
             data = json.loads(content)
         except Exception as e:
             logger.error("Bad POST request; Error was: %s", str(e))
@@ -157,17 +157,17 @@ class HttpBridge(Bridge):
         objects and to allow to recover the server using the address.
         """
         state = super().__getstate__()
-        state["server"] = None
-        state["server_thread"] = None
-        state["update_lock"] = None
-        state["address"] = self.server.server_address
+        state['server'] = None
+        state['server_thread'] = None
+        state['update_lock'] = None
+        state['address'] = self.server.server_address
         return state
 
     def __setstate__(self, state):
         """Load the state  and set up the server with the address in the state.
         """
         self.__dict__.update(state)
-        self._set_server(state["address"])
+        self._set_server(state['address'])
 
     def update_state(self, data):
         """Update the characteristics from the received data.
@@ -185,10 +185,10 @@ class HttpBridge(Bridge):
             }
         @type data: dict
         """
-        aid = data["aid"]
+        aid = data['aid']
         logger.debug("Got update from accessory with aid: %d", aid)
         accessory = self.accessories[aid]
-        service_data = data["services"]
+        service_data = data['services']
         for service, char_data in service_data.items():
             service_obj = accessory.get_service(service)
             for char, value in char_data.items():

--- a/pyhap/accessories/LightBulb.py
+++ b/pyhap/accessories/LightBulb.py
@@ -5,7 +5,6 @@ import RPi.GPIO as GPIO
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_LIGHTBULB
-import pyhap.loader as loader
 
 
 class LightBulb(Accessory):
@@ -20,6 +19,11 @@ class LightBulb(Accessory):
 
     def __init__(self, *args, pin=11, **kwargs):
         super().__init__(*args, **kwargs)
+
+        serv_light = self.add_preload_service('Lightbulb')
+        self.char_on = serv_light.configure_char(
+            'On', setter_callback=self.set_bulb)
+
         self.pin = pin
         self._gpio_setup(pin)
 
@@ -32,13 +36,6 @@ class LightBulb(Accessory):
             GPIO.output(self.pin, GPIO.HIGH)
         else:
             GPIO.output(self.pin, GPIO.LOW)
-
-    def _set_services(self):
-        super()._set_services()
-
-        bulb_service = loader.get_serv_loader().get_service("Lightbulb")
-        self.add_service(bulb_service)
-        bulb_service.get_characteristic("On").setter_callback = self.set_bulb
 
     def stop(self):
         super().stop()

--- a/pyhap/accessories/MotionSensor.py
+++ b/pyhap/accessories/MotionSensor.py
@@ -5,7 +5,6 @@ import RPi.GPIO as GPIO
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SENSOR
-import pyhap.loader as loader
 
 
 class MotionSensor(Accessory):
@@ -15,19 +14,14 @@ class MotionSensor(Accessory):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.detected_char = self.get_service("MotionSensor")\
-                                 .get_characteristic("MotionDetected")
+        serv_motion = self.add_preload_service('MotionSensor')
+        self.char_detected = serv_motion.configure_char('MotionDetected')
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(7, GPIO.IN)
         GPIO.add_event_detect(7, GPIO.RISING, callback=self._detected)
 
-    def _set_services(self):
-        super()._set_services()
-        self.add_service(
-            loader.get_serv_loader().get_service("MotionSensor"))
-
     def _detected(self, _pin):
-        self.detected_char.set_value(True)
+        self.char_detected.set_value(True)
 
     def stop(self):
         super().stop()

--- a/pyhap/accessories/SDS011.py
+++ b/pyhap/accessories/SDS011.py
@@ -4,7 +4,7 @@ An Accessory wrapper for the SDS011 air particulate density sensor.
 The density sensor implementation can be found here:
 https://github.com/ikalchev/py-sds011
 Place the file under a package named sensors in your python path,
-or change the import alltogether.
+or change the import altogether.
 """
 import time
 import logging
@@ -12,7 +12,6 @@ import logging
 from sensors.SDS011 import SDS011 as AirSensor
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SENSOR
-import pyhap.loader as loader
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class SDS011(Accessory):
     SORTED_PM_QUALITY_MAP = ((200, 5), (150, 4), (100, 3), (50, 2), (0, 1))
     """
     Threshold-to-state tuples. These show the state for which the threshold is
-    lower boundry. Uses something like Air Quality Index (AQI).
+    lower boundary. Uses something like Air Quality Index (AQI).
 
     The UI shows:
         1 - Excellent
@@ -36,9 +35,9 @@ class SDS011(Accessory):
         5 - Poor
     """
 
-    def __init__(self, serial_port, *args, sleep_duration_s=15*60, calib_duration_s=15,
-                 **kwargs):
-        """Initialise and start SDS011 on the given port.
+    def __init__(self, serial_port, *args, sleep_duration_s=15*60,
+                 calib_duration_s=15, **kwargs):
+        """Initialize and start SDS011 on the given port.
 
         @param serial_port: The SDS011 port, e.g. /dev/ttyUSB0.
         @type serial_port: str
@@ -56,62 +55,49 @@ class SDS011(Accessory):
         self.pm10_quality = None
         self.pm10_density = None
         super().__init__(*args, **kwargs)
+
+        # PM2.5
+        air_quality_pm25 = self.add_preload_serivce(
+            'AirQualitySensor', chars=['Name', 'AirParticulateSize',
+                                       'AirParticulateDensity'])
+        air_quality_pm25.configure_char('AirParticulateSize', value=0)
+        air_quality_pm25.configure_char('Name', value='PM2.5')
+        self.pm25_quality = air_quality_pm25.configure_char('AirQuality')
+        self.pm25_density = air_quality_pm25.configure_char(
+            'AirParticulateDensity')
+
+        # PM10
+        air_quality_pm10 = self.add_preload_serivce(
+            'AirQualitySensor', chars=['Name', 'AirParticulateSize',
+                                       'AirParticulateDensity'])
+        air_quality_pm10.configure_char('AirParticulateSize', value=1)
+        air_quality_pm10.configure_char('Name', value='PM10')
+        self.pm25_quality = air_quality_pm10.configure_char('AirQuality')
+        self.pm25_density = air_quality_pm10.configure_char(
+            'AirParticulateDensity')
+
         self.sleep_duration_s = sleep_duration_s
         self.calib_duration_s = calib_duration_s
         self.serial_port = serial_port
         self.sensor = AirSensor(serial_port)
         self.sensor.sleep(sleep=False)
 
-    def _set_services(self):
-        """Add the AirQualitySensor services (one for PM2.5 and one for PM10).
-
-        Also adds and configures optional characteristics, such as Name,
-        AirParticulateSize, AirParticulateDensity.
-        """
-        super()._set_services()
-        char_loader = loader.get_char_loader()
-
-        # PM2.5
-        air_quality_pm25 = loader.get_serv_loader() \
-            .get_service("AirQualitySensor")
-        pm25_size = char_loader.get_char("AirParticulateSize")
-        pm25_size.set_value(0, should_notify=False)
-        self.pm25_density = char_loader.get_char("AirParticulateDensity")
-        pm25_name = char_loader.get_char("Name")
-        pm25_name.set_value("PM2.5", should_notify=False)
-        self.pm25_quality = air_quality_pm25.get_characteristic("AirQuality")
-        air_quality_pm25.add_characteristic(pm25_name, pm25_size, self.pm25_density)
-
-        # PM10
-        air_quality_pm10 = loader.get_serv_loader() \
-            .get_service("AirQualitySensor")
-        pm10_size = char_loader.get_char("AirParticulateSize")
-        pm10_size.set_value(1, should_notify=False)
-        self.pm10_density = char_loader.get_char("AirParticulateDensity")
-        pm10_name = char_loader.get_char("Name")
-        pm10_name.set_value("PM10", should_notify=False)
-        self.pm10_quality = air_quality_pm10.get_characteristic("AirQuality")
-        air_quality_pm10.add_characteristic(pm10_name, pm10_size, self.pm10_density)
-
-        self.add_service(air_quality_pm25)
-        self.add_service(air_quality_pm10)
-
     def __getstate__(self):
         """Get the state, less the sensor.
         """
         state = super(SDS011, self).__getstate__()
-        state["sensor"] = None
+        state['sensor'] = None
         return state
 
     def __setstate__(self, state):
-        """Set the state of this Accessory and initialise the sensor
+        """Set the state of this Accessory and initialize the sensor
             with the serial port in the state.
         """
         self.__dict__.update(state)
         self.sensor = AirSensor(self.serial_port)
 
     def get_quality_classification(self, pm, is_pm25=False):
-        """Get the air quality clasification based on the PM density.
+        """Get the air quality classification based on the PM density.
 
         Uses Air Quality Index (AQI), without averaging for an hour.
 

--- a/pyhap/accessories/ShutdownSwitch.py
+++ b/pyhap/accessories/ShutdownSwitch.py
@@ -12,7 +12,6 @@ import logging
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SWITCH
-import pyhap.loader as loader
 
 logger = logging.getLogger(__name__)
 
@@ -23,17 +22,12 @@ class ShutdownSwitch(Accessory):
     category = CATEGORY_SWITCH
 
     def __init__(self, *args, **kwargs):
-        """Initialise and set a shutdown callback to the On characteristic."""
+        """Initialize and set a shutdown callback to the On characteristic."""
         super().__init__(*args, **kwargs)
-        on_char = self.get_service("Switch")\
-                      .get_characteristic("On")
-        on_char.setter_callback = self.execute_shutdown
 
-    def _set_services(self):
-        """Add the Switch service."""
-        super()._set_services()
-        service_loader = loader.get_serv_loader()
-        self.add_service(service_loader.get_service("Switch"))
+        serv_switch = self.add_preload_service('Switch')
+        self.char_on = serv_switch.configure_char(
+            'On', setter_callback=self.execute_shutdown)
 
     def execute_shutdown(self, _value):
         """Execute shutdown -h."""

--- a/pyhap/accessories/TSL2591.py
+++ b/pyhap/accessories/TSL2591.py
@@ -5,7 +5,6 @@ import tsl2591
 
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_SENSOR
-import pyhap.loader as loader
 
 
 class TSL2591(Accessory):
@@ -14,15 +13,10 @@ class TSL2591(Accessory):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.lux_char = self.get_service("LightSensor") \
-            .get_characteristic("CurrentAmbientLightLevel")
+        serv_light = self.add_preload_service('LightSensor')
+        self.char_lux = serv_light.configure_char('CurrentAmbientLightLevel')
 
         self.tsl = tsl2591.Tsl2591()
-
-    def _set_services(self):
-        super()._set_services()
-        self.add_service(
-            loader.get_serv_loader().get_service("LightSensor"))
 
     def __getstate__(self):
         state = super().__getstate__()
@@ -37,5 +31,5 @@ class TSL2591(Accessory):
         while not self.run_sentinel.wait(10):
             full, ir = self.tsl.get_full_luminosity()
             lux = min(max(0.001, self.tsl.calculate_lux(full, ir)), 10000)
-            self.lux_char.set_value(lux)
+            self.char_lux.set_value(lux)
 

--- a/pyhap/accessories/TemperatureSensor.py
+++ b/pyhap/accessories/TemperatureSensor.py
@@ -6,7 +6,7 @@ import time
 
 from pyhap.accessory import AsyncAccessory
 from pyhap.const import CATEGORY_SENSOR
-import pyhap.loader as loader
+
 
 class TemperatureSensor(AsyncAccessory):
 
@@ -15,14 +15,9 @@ class TemperatureSensor(AsyncAccessory):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.temp_char = self.get_service("TemperatureSensor")\
-                             .get_characteristic("CurrentTemperature")
-
-    def _set_services(self):
-        super()._set_services()
-        self.add_service(
-            loader.get_serv_loader().get_service("TemperatureSensor"))
+        serv_temp = self.add_preload_service('TemperatureSensor')
+        self.char_temp = serv_temp.configure_char('CurrentTemperature')
 
     @AsyncAccessory.run_at_interval(3)
     async def run(self):
-        self.temp_char.set_value(random.randint(18, 26))
+        self.char_temp.set_value(random.randint(18, 26))

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -85,6 +85,8 @@ class Accessory:
 
         self.add_info_service()
 
+        self._set_services()
+
     def __repr__(self):
         """Return the representation of the accessory."""
         services = [s.display_name for s in self.services]
@@ -108,6 +110,16 @@ class Accessory:
         if self._pincode is None:
             self._pincode = util.generate_pincode()
         return self._pincode
+
+    def _set_services(self):
+        """Sets the services for this accessory.
+
+        This method is now deprecated, initialize the service inside the
+        accessory `init` method.
+        """
+        logger.warning(
+            "The 'Accessory._set_services' method is deprecated. Initialize "
+            "the services inside the accessories 'init' method instead.")
 
     def add_info_service(self):
         """Helper method to add the required `AccessoryInformation` service.
@@ -140,7 +152,7 @@ class Accessory:
                     "be at least one character long.", self.display_name)
 
     def add_preload_service(self, service, chars=None):
-        """Define and return a service to be available for the accessory."""
+        """Create a service with the given name and add it to this acc."""
         service = get_serv_loader().get_service(service)
         if chars:
             chars = chars if isinstance(chars, list) else [chars]

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -13,7 +13,7 @@ from pyhap.const import (
     STANDALONE_AID, HAP_REPR_AID, HAP_REPR_IID, HAP_REPR_SERVICES,
     HAP_REPR_VALUE, CATEGORY_OTHER, CATEGORY_BRIDGE)
 from pyhap.iid_manager import IIDManager
-from pyhap.loader import get_serv_loader
+from pyhap.loader import get_serv_loader, get_char_loader
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class Accessory:
         self.services = []
         self.iid_manager = iid_manager or IIDManager()
 
-        self._set_services()
+        self.add_info_service()
 
     def __repr__(self):
         """Return the representation of the accessory."""
@@ -109,27 +109,46 @@ class Accessory:
             self._pincode = util.generate_pincode()
         return self._pincode
 
-    def _set_services(self):
-        """Sets the services for this accessory.
+    def add_info_service(self):
+        """Helper method to add the required `AccessoryInformation` service.
 
-        The default implementation adds only the AccessoryInformation services
-        and sets its Name characteristic to the Accessory's display name.
-
-        .. note:: When inheriting from Accessory and overriding this method,
-            always call the base implementation first, as it reserves IID of
-            1 for the Accessory Information service (HAP requirement).
+        Called in `__init__` to be sure that it is the first service added.
+        May be overridden.
         """
-        info_service = get_serv_loader().get_service("AccessoryInformation")
-        info_service.get_characteristic("Name")\
-                    .set_value(self.display_name, False)
-        info_service.get_characteristic("Manufacturer")\
-                    .set_value("Default-Manufacturer", False)
-        info_service.get_characteristic("Model")\
-                    .set_value("Default-Model", False)
-        info_service.get_characteristic("SerialNumber")\
-                    .set_value("Default-SerialNumber", False)
-        # FIXME: Need to ensure AccessoryInformation is with IID 1.
-        self.add_service(info_service)
+        serv_info = get_serv_loader().get_service('AccessoryInformation')
+        serv_info.configure_char('Name', value=self.display_name)
+        serv_info.configure_char('SerialNumber', value='default')
+        self.add_service(serv_info)
+
+    def set_info_service(self, firmware_revision=None, manufacturer=None,
+                         model=None, serial_number=None):
+        """Quick assign basic accessory information."""
+        serv_info = self.get_service('AccessoryInformation')
+        if firmware_revision:
+            serv_info.configure_char(
+                'FirmwareRevision', value=firmware_revision)
+        if manufacturer:
+            serv_info.configure_char('Manufacturer', value=manufacturer)
+        if model:
+            serv_info.configure_char('Model', value=model)
+        if serial_number:
+            if len(serial_number) >= 1:
+                serv_info.configure_char('SerialNumber', value=serial_number)
+            else:
+                logger.warning(
+                    "Couldn't add SerialNumber for %s. The SerialNumber must "
+                    "be at least one character long.", self.display_name)
+
+    def add_preload_service(self, service, chars=None):
+        """Define and return a service to be available for the accessory."""
+        service = get_serv_loader().get_service(service)
+        if chars:
+            chars = chars if isinstance(chars, list) else [chars]
+            for char_name in chars:
+                char = get_char_loader().get_char(char_name)
+                service.add_characteristic(char)
+        self.add_service(service)
+        return service
 
     def set_sentinel(self, run_sentinel, aio_stop_event, event_loop):
         """Assign a run sentinel that can signal stopping.


### PR DESCRIPTION
Split of from #92.

### Changes
- Added helper method to enable easy override of the `AccessoryInformation` service.
- Added helper method to load a service and chars and add it to an accessory.
- The `AccessoryInformation` service will always have the `iid=1`.
- Updated accessories to account for changes

### Breaking Changes
- Changed default values associated with the `AccessoryInformation` service.
- Removed accessory call to `Accessory._set_services`. Overriding this method not longer works. Instead services should be initialized in the accessories `init` method.