### PR TITLE
Improvements 6 - Changes, Driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Accessory.run method is now called through an event loop. You can either inherit from `Accessory` like before: The `run` method will be wrapped in a thread. Or inherit from `AsyncAccessory` and implement `async def run`. This will lead to the execution in the event loop. [#74](https://github.com/ikalchev/HAP-python/pull/74)
 - Scripts are now located in a separate directory: `scripts`. [#81](https://github.com/ikalchev/HAP-python/pull/81)
 - `driver.start` starts the event loop with `loop.run_forever()`. [#83](https://github.com/ikalchev/HAP-python/pull/83)
-- Debug logs for `char.set_value` and `char.client_update_value`
+- Debug logs for `char.set_value` and `char.client_update_value`. [#99](https://github.com/ikalchev/HAP-python/pull/99)
 
 ### Fixed
 - Overriding properties now checks that value is still a valid value, otherwise value will be set to the default value. [#82](https://github.com/ikalchev/HAP-python/pull/82)
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - With introduction of async methods the min required Python version changes to `3.5`. [#74](https://github.com/ikalchev/HAP-python/pull/74)
 - The `Accessory.Category` class was removed and the `Category` constants moved to `pyhap/const.py` with the naming: `CATEGORY_[OLD_NAME]` (e.g. `CATEGORY_OTHER`) [#86](https://github.com/ikalchev/HAP-python/pull/86)
 - Updated `Accessories` to work with changes. [#74](https://github.com/ikalchev/HAP-python/pull/74), [#89](https://github.com/ikalchev/HAP-python/pull/89)
+- Renamed `Accessory.broker` to `Accessory.Driver`. `acc.set_broker` is now `acc.set_driver`. [#104](https://github.com/ikalchev/HAP-python/pull/104)
 
 ### Developers
 - `to_HAP` methods don't require the `iid_manager` any more [#84](https://github.com/ikalchev/HAP-python/pull/84), [#85](https://github.com/ikalchev/HAP-python/pull/85)
@@ -34,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `TypeLoader`, `CharLoader` and `ServiceLoader` are now combined into the `TypeLoader` with the new methods `get_char` and `get_service` to load new chars and services. [85](https://github.com/ikalchev/HAP-python/pull/85)
 - Moved some constants to `pyhap/const.py` and removed `HAP_FORMAT`, `HAP_UNITS` and `HAP_PERMISSIONS` in favor for `HAP_FORMAT_[OLD_FORMAT]`, etc. [#86](https://github.com/ikalchev/HAP-python/pull/86)
 - Updated tests and added new test dependency `pytest-timeout` [#88](https://github.com/ikalchev/HAP-python/pull/88)
-- Rewrote `IIDManager` and split `IIDManager.remove` into `remove_obj` and `remove_iid`
+- Rewrote `IIDManager` and split `IIDManager.remove` into `remove_obj` and `remove_iid`. [#100](https://github.com/ikalchev/HAP-python/pull/100)
 
 
 

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -70,7 +70,7 @@ class Accessory:
         self.reachable = True
         self._pincode = pincode
         self._setup_id = setup_id
-        self.broker = None
+        self.driver = None
         # threading.Event that gets set when the Accessory should stop.
         self.run_sentinel = None
         self.event_loop = None
@@ -93,7 +93,7 @@ class Accessory:
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state['broker'] = None
+        state['driver'] = None
         state['run_sentinel'] = None
         return state
 
@@ -153,7 +153,7 @@ class Accessory:
         These include new services or updated characteristic values, e.g.
         the Name of a service changed.
 
-        This method also notifies the broker about the change, so that it can
+        This method also notifies the driver about the change, so that it can
         publish the changes to the world.
 
         .. note:: If you are changing the configuration of a bridged accessory
@@ -162,7 +162,7 @@ class Accessory:
 
         """
         self.config_version += 1
-        self.broker.config_changed()
+        self.driver.config_changed()
 
     def add_service(self, *servs):
         """Add the given services to this Accessory.
@@ -198,8 +198,8 @@ class Accessory:
         """
         return next((s for s in self.services if s.display_name == name), None)
 
-    def set_broker(self, broker):
-        self.broker = broker
+    def set_driver(self, driver):
+        self.driver = driver
 
     def add_paired_client(self, client_uuid, client_public):
         """Adds the given client to the set of paired clients.
@@ -333,14 +333,14 @@ class Accessory:
         """
         pass
 
-    # Broker
+    # Driver
 
     def publish(self, value, sender):
-        """Append AID and IID of the sender and forward it to the broker.
+        """Append AID and IID of the sender and forward it to the driver.
 
         Characteristics call this method to send updates.
 
-        .. note:: The method will not fail if the broker is not set - it will do nothing.
+        .. note:: The method will not fail if the driver is not set - it will do nothing.
 
         :param data: Data to publish, usually from a Characteristic.
         :type data: dict
@@ -348,7 +348,7 @@ class Accessory:
         :param sender: The Service or Characteristic from which the call originated.
         :type: Service or Characteristic
         """
-        if self.broker is None:
+        if self.driver is None:
             return
 
         acc_data = {
@@ -356,7 +356,7 @@ class Accessory:
             HAP_REPR_IID: self.iid_manager.get_iid(sender),
             HAP_REPR_VALUE: value,
         }
-        self.broker.publish(acc_data)
+        self.driver.publish(acc_data)
 
 
 class AsyncAccessory(Accessory):
@@ -445,10 +445,10 @@ class Bridge(AsyncAccessory):
 
         self.accessories[acc.aid] = acc
 
-    def set_broker(self, broker):
-        super().set_broker(broker)
+    def set_driver(self, driver):
+        super().set_driver(driver)
         for _, acc in self.accessories.items():
-            acc.broker = broker
+            acc.driver = driver
 
     def to_HAP(self):
         """Returns a HAP representation of itself and all contained accessories.

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -18,7 +18,7 @@ from pyhap.loader import get_serv_loader
 logger = logging.getLogger(__name__)
 
 
-class Accessory(object):
+class Accessory:
     """A representation of a HAP accessory.
 
     Inherit from this class to build your own accessories.
@@ -93,19 +93,19 @@ class Accessory(object):
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state["broker"] = None
-        state["run_sentinel"] = None
+        state['broker'] = None
+        state['run_sentinel'] = None
         return state
 
     @property
     def setup_id(self):
-        if not getattr(self, '_setup_id', None):
+        if self._setup_id is None:
             self._setup_id = util.generate_setup_id()
         return self._setup_id
 
     @property
     def pincode(self):
-        if not getattr(self, '_pincode', None):
+        if self._pincode is None:
             self._pincode = util.generate_pincode()
         return self._pincode
 
@@ -405,9 +405,8 @@ class Bridge(AsyncAccessory):
         # A Bridge cannot be Bridge, hence talks directly to HAP clients.
         # Thus, we need a mac.
         mac = mac or util.generate_mac()
-        super(Bridge, self).__init__(display_name, aid=aid, mac=mac,
-                                     pincode=pincode, iid_manager=iid_manager,
-                                     setup_id=setup_id)
+        super().__init__(display_name, aid=aid, mac=mac, pincode=pincode,
+                         iid_manager=iid_manager, setup_id=setup_id)
         self.accessories = {}  # aid: acc
 
     def set_sentinel(self, run_sentinel, aio_stop_event, event_loop):
@@ -447,7 +446,7 @@ class Bridge(AsyncAccessory):
         self.accessories[acc.aid] = acc
 
     def set_broker(self, broker):
-        super(Bridge, self).set_broker(broker)
+        super().set_broker(broker)
         for _, acc in self.accessories.items():
             acc.broker = broker
 
@@ -496,10 +495,10 @@ class Bridge(AsyncAccessory):
 
     def stop(self):
         """Calls stop() on all contained accessories."""
-        super(Bridge, self).stop()
+        super().stop()
         for acc in self.accessories.values():
             acc.stop()
 
 
 def get_topic(aid, iid):
-    return str(aid) + "." + str(iid)
+    return str(aid) + '.' + str(iid)

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -163,7 +163,7 @@ class AccessoryDriver:
         self.sent_events = 0
         self.accumulated_qsize = 0
 
-        self.accessory.set_broker(self)
+        self.accessory.set_driver(self)
         self.mdns_service_info = None
         self.srp_verifier = None
         self.accessory_thread = None

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -57,12 +57,12 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
     def __init__(self, accessory, address, port):
         self.accessory = accessory
         hname = socket.gethostname()
-        pubname = hname + "." if hname.endswith(".local") else hname + ".local."
+        pubname = hname + '.' if hname.endswith('.local') else hname + '.local.'
 
         adv_data = self._get_advert_data()
-        super(AccessoryMDNSServiceInfo, self).__init__(
-             "_hap._tcp.local.",
-             self.accessory.display_name + "._hap._tcp.local.",
+        super().__init__(
+             '_hap._tcp.local.',
+             self.accessory.display_name + '._hap._tcp.local.',
              socket.inet_aton(address),
              port,
              0,
@@ -78,26 +78,24 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
 
     def _get_advert_data(self):
         """Generate advertisement data from the accessory."""
-        adv_data = {
-            "md": self.accessory.display_name,
-            "pv": "1.0",
-            "id": self.accessory.mac,
-            # represents the "configuration version" of an Accessory.
-            # Increasing this "version number" signals iOS devices to
+        return {
+            'md': self.accessory.display_name,
+            'pv': '1.0',
+            'id': self.accessory.mac,
+            # represents the 'configuration version' of an Accessory.
+            # Increasing this 'version number' signals iOS devices to
             # re-fetch accessories data.
-            "c#": str(self.accessory.config_version),
-            "s#": "1",  # "accessory state"
-            "ff": "0",
-            "ci": str(self.accessory.category),
-            # "sf == 1" means "discoverable by HomeKit iOS clients"
-            "sf": "0" if self.accessory.paired else "1",
-            "sh": self._setup_hash()
+            'c#': str(self.accessory.config_version),
+            's#': '1',  # 'accessory state'
+            'ff': '0',
+            'ci': str(self.accessory.category),
+            # 'sf == 1' means "discoverable by HomeKit iOS clients"
+            'sf': '0' if self.accessory.paired else '1',
+            'sh': self._setup_hash()
         }
 
-        return adv_data
 
-
-class AccessoryDriver(object):
+class AccessoryDriver:
     """
     An AccessoryDriver mediates between incoming requests from the HAPServer and
     the Accessory.
@@ -273,15 +271,13 @@ class AccessoryDriver(object):
         self.advertiser.register_service(self.mdns_service_info)
 
     def persist(self):
-        """Saves the state of the accessory.
-        """
-        with open(self.persist_file, "w") as fp:
+        """Saves the state of the accessory."""
+        with open(self.persist_file, 'w') as fp:
             self.encoder.persist(fp, self.accessory)
 
     def load(self):
-        """
-        """
-        with open(self.persist_file, "r") as fp:
+        """ """
+        with open(self.persist_file, 'r') as fp:
             self.encoder.load_into(fp, self.accessory)
 
     def pair(self, client_uuid, client_public):
@@ -317,7 +313,7 @@ class AccessoryDriver(object):
         :param client_uuid: The client uuid.
         :type client_uuid: uuid.UUID
         """
-        logger.info("Unpairing client '%s'.", client_uuid)
+        logger.info("Unpairing client %s.", client_uuid)
         self.accessory.remove_paired_client(client_uuid)
         self.persist()
         self.update_advertisement()
@@ -326,7 +322,7 @@ class AccessoryDriver(object):
         """Create an SRP verifier for the accessory's info."""
         # TODO: Move the below hard-coded values somewhere nice.
         ctx = get_srp_context(3072, hashlib.sha512, 16)
-        verifier = SrpServer(ctx, b"Pair-Setup", self.accessory.pincode)
+        verifier = SrpServer(ctx, b'Pair-Setup', self.accessory.pincode)
         self.srp_verifier = verifier
 
     def get_accessories(self):
@@ -381,7 +377,7 @@ class AccessoryDriver(object):
         """
         chars = []
         for id in char_ids:
-            aid, iid = (int(i) for i in id.split("."))
+            aid, iid = (int(i) for i in id.split('.'))
             rep = {HAP_REPR_AID: aid, HAP_REPR_IID: iid}
             char = self.accessory.get_characteristic(aid, iid)
             try:
@@ -463,7 +459,7 @@ class AccessoryDriver(object):
         All of the above are started in separate threads. Accessory thread is set as
         daemon.
         """
-        logger.info("Starting accessory '%s' on address '%s', port '%s'.",
+        logger.info("Starting accessory %s on address %s, port %s.",
                     self.accessory.display_name, self.address, self.port)
 
         # Start sending events to clients. This is done in a daemon thread, because:
@@ -520,7 +516,7 @@ class AccessoryDriver(object):
         """
         # TODO: This should happen in a different order - mDNS, server, accessory. Need
         # to ensure that sending with a closed server will not crash the app.
-        logger.info("Stoping accessory '%s' on address %s, port %s.",
+        logger.info("Stoping accessory %s on address %s, port %s.",
                     self.accessory.display_name, self.address, self.port)
         logger.debug("Setting stop events, stopping accessory and event sending")
         self.stop_event.set()

--- a/pyhap/encoder.py
+++ b/pyhap/encoder.py
@@ -10,7 +10,7 @@ import ed25519
 
 from pyhap.util import fromhex, tohex
 
-class AccessoryEncoder(object):
+class AccessoryEncoder:
     """This class defines the Accessory encoder interface.
 
     The AccessoryEncoder is used by the AccessoryDriver to persist and restore the
@@ -53,11 +53,11 @@ class AccessoryEncoder(object):
         paired_clients = {str(client): tohex(key)
                           for client, key in acc.paired_clients.items()}
         config_state = {
-            "mac": acc.mac,
-            "config_version": acc.config_version,
-            "paired_clients": paired_clients,
-            "private_key": tohex(acc.private_key.to_seed()),
-            "public_key":  tohex(acc.public_key.to_bytes()),
+            'mac': acc.mac,
+            'config_version': acc.config_version,
+            'paired_clients': paired_clients,
+            'private_key': tohex(acc.private_key.to_seed()),
+            'public_key':  tohex(acc.public_key.to_bytes()),
         }
         json.dump(config_state, fp)
 
@@ -67,9 +67,9 @@ class AccessoryEncoder(object):
         @see: AccessoryEncoder.persist
         """
         state = json.load(fp)
-        acc.mac = state["mac"]
-        acc.config_version = state["config_version"]
+        acc.mac = state['mac']
+        acc.config_version = state['config_version']
         acc.paired_clients = {uuid.UUID(client): fromhex(key)
-                              for client, key in state["paired_clients"].items()}
-        acc.private_key = ed25519.SigningKey(fromhex(state["private_key"]))
-        acc.public_key = ed25519.VerifyingKey(fromhex(state["public_key"]))
+                              for client, key in state['paired_clients'].items()}
+        acc.private_key = ed25519.SigningKey(fromhex(state['private_key']))
+        acc.public_key = ed25519.VerifyingKey(fromhex(state['public_key']))


### PR DESCRIPTION
Split of from #92.

### Changes
- Replaced double `"` for parameter values with `'`.
- Removed `object` inheritance
- Removed class from super calls if obvious

### Breaking Changes
- Changed `Accessory.broker` to `Accessory.driver`. Also `acc.set_broker` is now `acc.set_driver`.

---

Also the change to `driver` might not be entirely necessary, it simplifies things with the better name.