### PR TITLE
Improvements 6 - Driver assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,32 @@ Sections
 ### Added
 ### Changed
 ### Deprecated
+### Removed
 ### Fixed
 ### Breaking Changes
 ### Developers
 -->
+
+## [Unreleased]
+
+### Added
+- Option to pass custom loader object to `driver` with parameter `loader`. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+- Default port for `accessory_driver.port = 51234`. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+
+### Changed
+- The `loader` object is now stored in the `driver` and can be accessed through `driver.loader`. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+
+### Removed
+- The `Loader` methods `get_loader`, `get_char_loader` and `get_serv_loader` have bee removed. To add a service to an accessory, use `acc.add_preload_service()` instead. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+
+### Breaking Changes
+- The `driver` doesn't take the top `accessory` anymore. Instead it's added through `driver.add_accessory()` after the initialization. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+- All `driver` init parameter are now required to be passed as keywords. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+- Any `accessory` needs the `driver` object for its initialization, passed as first argument. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+
+### Developers
+- Removed `acc.set_driver()` and `acc.set_sentinel()` methods. `acc.run_sentinel`, `acc.aio_stop_event` and `acc.loop` are now accessed through `acc.driver.xxx`. `run_sentinel` is changed to `stop_event`. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+
 
 
 ## [2.1.0] - 2018-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,6 @@ Sections
 ### Changed
 - The `loader` object is now stored in the `driver` and can be accessed through `driver.loader`. [#105](https://github.com/ikalchev/HAP-python/pull/105)
 
-### Removed
-- The `Loader` methods `get_loader`, `get_char_loader` and `get_serv_loader` have bee removed. To add a service to an accessory, use `acc.add_preload_service()` instead. [#105](https://github.com/ikalchev/HAP-python/pull/105)
-
 ### Breaking Changes
 - The `driver` doesn't take the top `accessory` anymore. Instead it's added through `driver.add_accessory()` after the initialization. [#105](https://github.com/ikalchev/HAP-python/pull/105)
 - All `driver` init parameter are now required to be passed as keywords. [#105](https://github.com/ikalchev/HAP-python/pull/105)

--- a/accessories/AM2302.py
+++ b/accessories/AM2302.py
@@ -40,11 +40,11 @@ class AM2302(Accessory):
         self.__dict__.update(state)
         self.sensor = DHT22.sensor(pigpio.pi(), self.pin)
 
+    @Accessory.run_at_interval(10)
     def run(self):
-        while not self.run_sentinel.wait(10):
-            self.sensor.trigger()
-            time.sleep(0.2)
-            t = self.sensor.temperature()
-            h = self.sensor.humidity()
-            self.char_temp.set_value(t)
-            self.char_humidity.set_value(h)
+        self.sensor.trigger()
+        time.sleep(0.2)
+        t = self.sensor.temperature()
+        h = self.sensor.humidity()
+        self.char_temp.set_value(t)
+        self.char_humidity.set_value(h)

--- a/accessories/BMP180.py
+++ b/accessories/BMP180.py
@@ -28,7 +28,7 @@ class BMP180(Accessory):
         self.__dict__.update(state)
         self.sensor = sensor()
 
+    @Accessory.run_at_interval(30)
     def run(self):
-        while not self.run_sentinel.wait(30):
-            temp, _pressure = self.sensor.read()
-            self.char_temp.set_value(temp)
+        temp, _pressure = self.sensor.read()
+        self.char_temp.set_value(temp)

--- a/accessories/DisplaySwitch.py
+++ b/accessories/DisplaySwitch.py
@@ -32,14 +32,14 @@ class DisplaySwitch(Accessory):
         self.display = serv_switch.configure_char(
             'On', setter_callback=self.set_display)
 
+    @Accessory.run_at_interval(1)
     def run(self):
-        while not self.run_sentinel.wait(1):
-            # We can't just use .set_value(state), because that will
-            # trigger our listener.
-            state = get_display_state()
-            if self.display.value != state:
-                self.display.value = state
-                self.display.notify()
+        # We can't just use .set_value(state), because that will
+        # trigger our listener.
+        state = get_display_state()
+        if self.display.value != state:
+            self.display.value = state
+            self.display.notify()
 
     def set_display(self, state):
         if get_display_state() != state:

--- a/accessories/SDS011.py
+++ b/accessories/SDS011.py
@@ -126,7 +126,7 @@ class SDS011(Accessory):
         self.pm10_quality.set_value(
             self.get_quality_classification(pm10, is_pm25=False))
         self.sensor.sleep()
-        while not self.run_sentinel.wait(self.sleep_duration_s):
+        while not self.driver.stop_event.wait(self.sleep_duration_s):
             logger.debug("Waking up sensor.")
             self.sensor.sleep(sleep=False)
             time.sleep(self.calib_duration_s)

--- a/accessories/TSL2591.py
+++ b/accessories/TSL2591.py
@@ -27,9 +27,8 @@ class TSL2591(Accessory):
         self.__dict__.update(state)
         self.tsl = tsl2591.Tsl2591()
 
+    @Accessory.run_at_interval(10)
     def run(self):
-        while not self.run_sentinel.wait(10):
-            full, ir = self.tsl.get_full_luminosity()
-            lux = min(max(0.001, self.tsl.calculate_lux(full, ir)), 10000)
-            self.char_lux.set_value(lux)
-
+        full, ir = self.tsl.get_full_luminosity()
+        lux = min(max(0.001, self.tsl.calculate_lux(full, ir)), 10000)
+        self.char_lux.set_value(lux)

--- a/main.py
+++ b/main.py
@@ -20,9 +20,9 @@ from TemperatureSensor import TemperatureSensor
 logging.basicConfig(level=logging.INFO)
 
 
-def get_bridge():
+def get_bridge(driver):
     """Call this method to get a Bridge instead of a standalone accessory."""
-    bridge = Bridge(display_name='Bridge')
+    bridge = Bridge(driver, display_name='Bridge')
     temp_sensor = TemperatureSensor('Sensor 2')
     temp_sensor2 = TemperatureSensor('Sensor 1')
     bridge.add_accessory(temp_sensor)
@@ -31,16 +31,18 @@ def get_bridge():
     return bridge
 
 
-def get_accessory():
+def get_accessory(driver):
     """Call this method to get a standalone Accessory."""
-    acc = TemperatureSensor('MyTempSensor')
+    acc = TemperatureSensor(driver, 'MyTempSensor')
     return acc
 
 
-acc = get_accessory()  # Change to get_bridge() if you want to run a Bridge.
-
 # Start the accessory on port 51826
-driver = AccessoryDriver(acc, port=51826)
+driver = AccessoryDriver(port=51826)
+
+acc = get_accessory(driver)  # Change to get_bridge(driver) if you want to run a Bridge.
+driver.add_accessory(acc)
+
 # We want KeyboardInterrupts and SIGTERM (kill) to be handled by the driver itself,
 # so that it can gracefully stop the accessory, server and advertising.
 signal.signal(signal.SIGINT, driver.signal_handler)

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -30,7 +30,7 @@ class Accessory:
 
     category = CATEGORY_OTHER
 
-    def __init__(self, display_name, aid=None, mac=None, pincode=None):
+    def __init__(self, driver, display_name, *, aid=None):
         """Initialise with the given properties.
 
         :param display_name: Name to be displayed in the Home app.
@@ -42,35 +42,19 @@ class Accessory:
             will assign the standalone AID to this `Accessory`.
         :type aid: int
 
-        :param mac: Deprecated.
-
-        :param pincode: Deprecated.
-
         :param setup_id: Setup ID can be provided, although, per spec, should be random
             every time the instance is started. If not provided on init, will be random.
             4 digit string 0-9 A-Z
         :type setup_id: str
         """
-        if mac or pincode:
-            logger.warning(
-                "The 'mac' and 'pincode' parameter are now deprecated."
-                "Assign the 'pincode' to the driver instead.")
-        self.display_name = display_name
         self.aid = aid
-        self.mac = mac
+        self.display_name = display_name
+        self.driver = driver
         self.reachable = True
-        self._pincode = pincode
-        self.driver = None
-        # threading.Event that gets set when the Accessory should stop.
-        self.run_sentinel = None
-        self.loop = None
-        self.aio_stop_event = None
-
         self.services = []
         self.iid_manager = IIDManager()
 
         self.add_info_service()
-
         self._set_services()
 
     def __repr__(self):
@@ -135,22 +119,6 @@ class Accessory:
         self.add_service(service)
         return service
 
-    def set_sentinel(self, run_sentinel, aio_stop_event, loop):
-        """Assign a run sentinel that can signal stopping.
-
-        The run sentinel is a threading.Event object that can be used to manage
-        continuous running of the Accessory, e.g. a loop reading from a sensor every 3
-        seconds. The sentinel is "set" typically by the AccessoryDriver just before
-        Accessory.stop is called.
-
-        Example usage in the run method:
-        >>> while not self.run_sentinel.wait(3): # If not set, every 3 seconds
-        ...    sensor.readTemperature()
-        """
-        self.run_sentinel = run_sentinel
-        self.aio_stop_event = aio_stop_event
-        self.loop = loop
-
     def config_changed(self):
         """Notify the accessory about configuration changes.
 
@@ -204,13 +172,6 @@ class Accessory:
         :rtype: Service
         """
         return next((s for s in self.services if s.display_name == name), None)
-
-    def set_driver(self, driver):
-        self.driver = driver
-        if self.mac:
-            self.driver.state.mac = self.mac
-        if self._pincode:
-            self.driver.state.pincode = self._pincode
 
     def xhm_uri(self):
         """Generates the X-HM:// uri (Setup Code URI)
@@ -306,7 +267,7 @@ class Accessory:
         # decorator returns a decorator with the argument it got
         def _repeat(func):
             def _wrapper(self, *args, **kwargs):
-                while not self.run_sentinel.wait(seconds):
+                while not self.driver.stop_event.wait(seconds):
                     func(self, *args, **kwargs)
             return _wrapper
         return _repeat
@@ -329,17 +290,12 @@ class Accessory:
 
         Characteristics call this method to send updates.
 
-        .. note:: The method will not fail if the driver is not set - it will do nothing.
-
         :param data: Data to publish, usually from a Characteristic.
         :type data: dict
 
         :param sender: The Service or Characteristic from which the call originated.
         :type: Service or Characteristic
         """
-        if self.driver is None:
-            return
-
         acc_data = {
             HAP_REPR_AID: self.aid,
             HAP_REPR_IID: self.iid_manager.get_iid(sender),
@@ -367,9 +323,9 @@ class AsyncAccessory(Accessory):
         # decorator returns a decorator with the argument it got
         def _repeat(func):
             async def _wrapper(self, *args, **kwargs):
-                while not await util.event_wait(self.aio_stop_event,
+                while not await util.event_wait(self.driver.aio_stop_event,
                                                 seconds,
-                                                self.loop):
+                                                self.driver.loop):
                     await func(self, *args, **kwargs)
             return _wrapper
         return _repeat
@@ -387,21 +343,9 @@ class Bridge(AsyncAccessory):
 
     category = CATEGORY_BRIDGE
 
-    def __init__(self, display_name, mac=None, pincode=None):
-        """
-        :param mac: Deprecated.
-
-        :param pincode: Deprecated.
-        """
-        super().__init__(display_name, aid=STANDALONE_AID, mac=mac,
-                         pincode=pincode)
+    def __init__(self, driver, display_name):
+        super().__init__(driver, display_name, aid=STANDALONE_AID)
         self.accessories = {}  # aid: acc
-
-    def set_sentinel(self, run_sentinel, aio_stop_event, loop):
-        """Set the same sentinel to all contained accessories."""
-        super().set_sentinel(run_sentinel, aio_stop_event, loop)
-        for acc in self.accessories.values():
-            acc.set_sentinel(run_sentinel, aio_stop_event, loop)
 
     def add_accessory(self, acc):
         """Add the given ``Accessory`` to this ``Bridge``.
@@ -433,11 +377,6 @@ class Bridge(AsyncAccessory):
 
         self.accessories[acc.aid] = acc
 
-    def set_driver(self, driver):
-        super().set_driver(driver)
-        for _, acc in self.accessories.items():
-            acc.driver = driver
-
     def to_HAP(self):
         """Returns a HAP representation of itself and all contained accessories.
 
@@ -467,11 +406,11 @@ class Bridge(AsyncAccessory):
         tasks = []
         for acc in self.accessories.values():
             if isinstance(acc, AsyncAccessory):
-                task = self.loop.create_task(acc.run())
+                task = self.driver.loop.create_task(acc.run())
             else:
-                task = self.loop.create_task(self._wrap_in_thread(acc.run))
+                task = self.driver.loop.create_task(self._wrap_in_thread(acc.run))
             tasks.append(task)
-        await asyncio.gather(*tasks, loop=self.loop)
+        await asyncio.gather(*tasks, loop=self.driver.loop)
 
     def stop(self):
         """Calls stop() on all contained accessories."""

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -10,7 +10,6 @@ from pyhap.const import (
     STANDALONE_AID, HAP_REPR_AID, HAP_REPR_IID, HAP_REPR_SERVICES,
     HAP_REPR_VALUE, CATEGORY_OTHER, CATEGORY_BRIDGE)
 from pyhap.iid_manager import IIDManager
-from pyhap.loader import get_loader
 
 if SUPPORT_QR_CODE:
     import base36
@@ -30,7 +29,7 @@ class Accessory:
 
     category = CATEGORY_OTHER
 
-    def __init__(self, driver, display_name, *, aid=None):
+    def __init__(self, driver, display_name, aid=None):
         """Initialise with the given properties.
 
         :param display_name: Name to be displayed in the Home app.
@@ -83,7 +82,7 @@ class Accessory:
         Called in `__init__` to be sure that it is the first service added.
         May be overridden.
         """
-        serv_info = get_loader().get_service('AccessoryInformation')
+        serv_info = self.driver.loader.get_service('AccessoryInformation')
         serv_info.configure_char('Name', value=self.display_name)
         serv_info.configure_char('SerialNumber', value='default')
         self.add_service(serv_info)
@@ -109,12 +108,11 @@ class Accessory:
 
     def add_preload_service(self, service, chars=None):
         """Create a service with the given name and add it to this acc."""
-        loader = get_loader()
-        service = loader.get_service(service)
+        service = self.driver.loader.get_service(service)
         if chars:
             chars = chars if isinstance(chars, list) else [chars]
             for char_name in chars:
-                char = loader.get_char(char_name)
+                char = self.driver.loader.get_char(char_name)
                 service.add_characteristic(char)
         self.add_service(service)
         return service

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -42,6 +42,7 @@ from pyhap.const import (
 from pyhap.encoder import AccessoryEncoder
 from pyhap.hap_server import HAPServer
 from pyhap.hsrp import Server as SrpServer
+from pyhap.loader import Loader
 from pyhap.params import get_srp_context
 from pyhap.state import State
 
@@ -105,7 +106,7 @@ class AccessoryDriver:
 
     def __init__(self, *, address=None, port=51234,
                  persist_file='accessory.state', pincode=None,
-                 encoder=None):
+                 encoder=None, loader=None):
         """
         Initialize a new AccessoryDriver object.
 
@@ -139,6 +140,7 @@ class AccessoryDriver:
         self.encoder = encoder or AccessoryEncoder()
         self.topics = {}  # topic: set of (address, port) of subscribed clients
         self.topic_lock = threading.Lock()  # for exclusive access to the topics
+        self.loader = loader or Loader()
         self.loop = asyncio.new_event_loop()
         self.aio_stop_event = asyncio.Event(loop=self.loop)
         self.stop_event = threading.Event()

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -103,17 +103,11 @@ class AccessoryDriver:
 
     NUM_EVENTS_BEFORE_STATS = 100
 
-    def __init__(self, accessory, port, address=None,
-                 persist_file='accessory.state', encoder=None, pincode=None):
+    def __init__(self, *, address=None, port=51234,
+                 persist_file='accessory.state', pincode=None,
+                 encoder=None):
         """
         Initialize a new AccessoryDriver object.
-
-        :param accessory: The `Accessory` to be managed by this driver. The `Accessory`
-            must have the standalone AID (`pyhap.accessory.STANDALONE_AID`). If the
-            AID of the `Accessory` is None, the standalone AID will be assigned to it.
-            Also, if the mac of the `Accessory` is None, a randomly-generated one
-            will be assigned to it.
-        :type accessory: Accessory
 
         :param pincode: The pincode that HAP clients must prove they know in order
             to pair with this `Accessory`. Defaults to None, in which case a random
@@ -138,11 +132,7 @@ class AccessoryDriver:
         :param encoder: The encoder to use when persisting/loading the Accessory state.
         :type encoder: AccessoryEncoder
         """
-        if accessory.aid is None:
-            accessory.aid = STANDALONE_AID
-        elif accessory.aid != STANDALONE_AID:
-            raise ValueError("Top-level accessory must have the standalone AID.")
-        self.accessory = accessory
+        self.accessory = None
         self.http_server_thread = None
         self.advertiser = Zeroconf()
         self.persist_file = os.path.expanduser(persist_file)
@@ -157,7 +147,6 @@ class AccessoryDriver:
         self.sent_events = 0
         self.accumulated_qsize = 0
 
-        self.accessory.set_driver(self)
         self.mdns_service_info = None
         self.srp_verifier = None
         self.accessory_thread = None
@@ -166,6 +155,13 @@ class AccessoryDriver:
         network_tuple = (self.state.address, self.state.port)
         self.http_server = HAPServer(network_tuple, self)
 
+    def add_accessory(self, accessory):
+        """Add top level accessory to driver."""
+        self.accessory = accessory
+        if accessory.aid is None:
+            accessory.aid = STANDALONE_AID
+        elif accessory.aid != STANDALONE_AID:
+            raise ValueError("Top-level accessory must have the AID == 1.")
         if os.path.exists(self.persist_file):
             logger.info("Loading Accessory state from `%s`", self.persist_file)
             self.load()
@@ -464,6 +460,9 @@ class AccessoryDriver:
         All of the above are started in separate threads. Accessory thread is set as
         daemon.
         """
+        if self.accessory is None:
+            raise ValueError("You must assign an accessory to the driver, "
+                             "before you can start it.")
         logger.info("Starting accessory %s on address %s, port %s.",
                     self.accessory.display_name, self.state.address,
                     self.state.port)
@@ -492,8 +491,6 @@ class AccessoryDriver:
             self.accessory.setup_message()
 
         # Start the accessory so it can do stuff.
-        self.accessory.set_sentinel(self.stop_event, self.aio_stop_event,
-                                    self.loop)
         if isinstance(self.accessory, AsyncAccessory):
             self.accessory_task = self.loop.create_task(
                 self.accessory.run())

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -78,7 +78,7 @@ class Characteristic:
     like format, min and max values, valid values and others.
     """
 
-    __slots__ = ('display_name', 'type_id', 'properties', 'broker',
+    __slots__ = ('broker', 'display_name', 'properties', 'type_id',
                  'value', 'getter_callback', 'setter_callback')
 
     def __init__(self, display_name, type_id, properties):
@@ -95,10 +95,10 @@ class Characteristic:
             ValidValues, etc.
         :type properties: dict
         """
-        self.display_name = display_name
-        self.type_id = type_id
-        self.properties = properties
         self.broker = None
+        self.display_name = display_name
+        self.properties = properties
+        self.type_id = type_id
         self.value = self._get_default_value()
         self.getter_callback = None
         self.setter_callback = None

--- a/pyhap/loader.py
+++ b/pyhap/loader.py
@@ -8,14 +8,16 @@ instance of it (as long as it is described in some
 json file).
 """
 import json
-import logging
 
 from pyhap import CHARACTERISTICS_FILE, SERVICES_FILE
 from pyhap.characteristic import Characteristic
 from pyhap.service import Service
 
-_loader = None
-logger = logging.getLogger(__name__)
+
+def read_file(path):
+    """Read file and return a dict."""
+    with open(path, 'r') as file:
+        return json.load(file)
 
 
 class Loader:
@@ -28,13 +30,8 @@ class Loader:
     def __init__(self, path_char=CHARACTERISTICS_FILE,
                  path_service=SERVICES_FILE):
         """Initialize a new Loader instance."""
-        self.char_types = self._read_file(path_char)
-        self.serv_types = self._read_file(path_service)
-
-    def _read_file(self, path):
-        """Read file and return a dict."""
-        with open(path, 'r') as file:
-            return json.load(file)
+        self.char_types = read_file(path_char)
+        self.serv_types = read_file(path_service)
 
     def get_char(self, name):
         """Return new Characteristic object."""
@@ -60,38 +57,3 @@ class Loader:
         loader.char_types = char_dict or {}
         loader.serv_types = serv_dict or {}
         return loader
-
-
-def get_loader():
-    """Get a service and char loader.
-
-    If already initialized it returns the existing one.
-    """
-    global _loader
-    if _loader is None:
-        _loader = Loader()
-    return _loader
-
-
-# pylint: disable=unused-argument
-def get_char_loader(desc_file=None):
-    """Get a CharacteristicLoader with characteristic descriptions in the given file.
-
-    .. deprecated:: 2.0
-       Use `get_loader` instead.
-    """
-    logger.warning(
-        "'get_char_loader' is deprecated. Use 'get_loader' instead.")
-    return get_loader()
-
-
-# pylint: disable=unused-argument
-def get_serv_loader(desc_file=None):
-    """Get a ServiceLoader with service descriptions in the given file.
-
-    .. deprecated:: 2.0
-       Use `get_loader` instead.
-    """
-    logger.warning(
-        "'get_serv_loader' is deprecated. Use 'get_loader' instead.")
-    return get_loader()

--- a/pyhap/loader.py
+++ b/pyhap/loader.py
@@ -8,16 +8,14 @@ instance of it (as long as it is described in some
 json file).
 """
 import json
+import logging
 
 from pyhap import CHARACTERISTICS_FILE, SERVICES_FILE
 from pyhap.characteristic import Characteristic
 from pyhap.service import Service
 
-
-def read_file(path):
-    """Read file and return a dict."""
-    with open(path, 'r') as file:
-        return json.load(file)
+_loader = None
+logger = logging.getLogger(__name__)
 
 
 class Loader:
@@ -30,8 +28,14 @@ class Loader:
     def __init__(self, path_char=CHARACTERISTICS_FILE,
                  path_service=SERVICES_FILE):
         """Initialize a new Loader instance."""
-        self.char_types = read_file(path_char)
-        self.serv_types = read_file(path_service)
+        self.char_types = self._read_file(path_char)
+        self.serv_types = self._read_file(path_service)
+
+    @staticmethod
+    def _read_file(path):
+        """Read file and return a dict."""
+        with open(path, 'r') as file:
+            return json.load(file)
 
     def get_char(self, name):
         """Return new Characteristic object."""
@@ -57,3 +61,39 @@ class Loader:
         loader.char_types = char_dict or {}
         loader.serv_types = serv_dict or {}
         return loader
+
+
+def get_loader():
+    """Get a service and char loader.
+
+    If already initialized it returns the existing one.
+    """
+    # pylint: disable=global-statement
+    global _loader
+    if _loader is None:
+        _loader = Loader()
+    return _loader
+
+
+# pylint: disable=unused-argument
+def get_char_loader(desc_file=None):
+    """Get a CharacteristicLoader with characteristic descriptions in the given file.
+
+    .. deprecated:: 2.0
+       Use `get_loader` instead.
+    """
+    logger.warning(
+        "'get_char_loader' is deprecated. Use 'get_loader' instead.")
+    return get_loader()
+
+
+# pylint: disable=unused-argument
+def get_serv_loader(desc_file=None):
+    """Get a ServiceLoader with service descriptions in the given file.
+
+    .. deprecated:: 2.0
+       Use `get_loader` instead.
+    """
+    logger.warning(
+        "'get_serv_loader' is deprecated. Use 'get_loader' instead.")
+    return get_loader()

--- a/pyhap/service.py
+++ b/pyhap/service.py
@@ -11,14 +11,14 @@ class Service:
     TemperatureSensor service has the characteristic CurrentTemperature.
     """
 
-    __slots__ = ('display_name', 'type_id', 'characteristics', 'broker')
+    __slots__ = ('broker', 'characteristics', 'display_name', 'type_id')
 
     def __init__(self, type_id, display_name=None):
         """Initialize a new Service object."""
+        self.broker = None
+        self.characteristics = []
         self.display_name = display_name
         self.type_id = type_id
-        self.characteristics = []
-        self.broker = None
 
     def __repr__(self):
         """Return the representation of the service."""

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,7 @@ disable=
   too-few-public-methods,
   too-many-arguments,
   too-many-branches,
+  too-many-function-args,
   too-many-instance-attributes,
   too-many-lines,
   too-many-locals,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pyhap.loader import Loader
+
+
+@pytest.fixture(scope='session')
+def mock_driver():
+    yield MockDriver()
+
+
+class MockDriver():
+
+    def __init__(self):
+        self.loader = Loader()
+
+    def publish(self, data):
+        pass

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -1,71 +1,66 @@
 """Tests for pyhap.accessory."""
-from unittest.mock import patch
-
 import pytest
 
 from pyhap.accessory import Accessory, Bridge
-from pyhap.accessory_driver import AccessoryDriver
 from pyhap.const import STANDALONE_AID
 
-with patch('pyhap.accessory_driver.HAPServer'), \
-        patch('pyhap.accessory_driver.Zeroconf'):
-    DRIVER = AccessoryDriver()
+
+# #### Accessory ######
+# execute with `-k acc`
+# #####################
+
+def test_acc_init(mock_driver):
+    Accessory(mock_driver, 'Test Accessory')
 
 
-# #### Accessory ####
-# ###################
-
-def test_init():
-    Accessory(DRIVER, 'Test Accessory')
-
-
-def test_publish_no_broker():
-    acc = Accessory(DRIVER, 'Test Accessory')
+def test_acc_publish_no_broker(mock_driver):
+    acc = Accessory(mock_driver, 'Test Accessory')
     service = acc.driver.loader.get_service('TemperatureSensor')
     char = service.get_characteristic('CurrentTemperature')
     acc.add_service(service)
     char.set_value(25, should_notify=True)
 
 
-def test_set_services_compatible():
+def test_acc_set_services_compatible(mock_driver):
     """Test deprecated method _set_services."""
     class Acc(Accessory):
         def _set_services(self):
             super()._set_services()
             serv = self.driver.loader.get_service('TemperatureSensor')
             self.add_service(serv)
-    acc = Acc(DRIVER, 'Test Accessory')
+    acc = Acc(mock_driver, 'Test Accessory')
     assert acc.get_service('AccessoryInformation') is not None
     assert acc.get_service('TemperatureSensor') is not None
 
 
-# #### Bridge ####
-# ################
+# #### Bridge ############
+# execute with `-k bridge`
+# ########################
 
-def test_init_bridge():
-    Bridge(DRIVER, 'Test Bridge')
+def test_bridge_init(mock_driver):
+    Bridge(mock_driver, 'Test Bridge')
 
 
-def test_add_accessory():
-    bridge = Bridge(DRIVER, 'Test Bridge')
-    acc = Accessory(DRIVER, 'Test Accessory', aid=2)
+def test_bridge_add_accessory(mock_driver):
+    bridge = Bridge(mock_driver, 'Test Bridge')
+    acc = Accessory(mock_driver, 'Test Accessory', aid=2)
     bridge.add_accessory(acc)
-    acc2 = Accessory(DRIVER, 'Test Accessory 2')
+    acc2 = Accessory(mock_driver, 'Test Accessory 2')
     bridge.add_accessory(acc2)
     assert acc2.aid != STANDALONE_AID and acc2.aid != acc.aid
 
 
-def test_n_add_accessory_bridge_aid():
-    bridge = Bridge(DRIVER, 'Test Bridge')
-    acc = Accessory(DRIVER, 'Test Accessory', aid=STANDALONE_AID)
+def test_bridge_n_add_accessory_bridge_aid(mock_driver):
+    bridge = Bridge(mock_driver, 'Test Bridge')
+    acc = Accessory(mock_driver, 'Test Accessory', aid=STANDALONE_AID)
     with pytest.raises(ValueError):
         bridge.add_accessory(acc)
 
 
-def test_n_add_accessory_dup_aid():
-    bridge = Bridge(DRIVER, 'Test Bridge')
-    acc_1 = Accessory(DRIVER, 'Test Accessory 1', aid=2)
-    acc_2 = Accessory(DRIVER, 'Test Accessory 2', aid=acc_1.aid)
+def test_bridge_n_add_accessory_dup_aid(mock_driver):
+    bridge = Bridge(mock_driver, 'Test Bridge')
+    acc_1 = Accessory(mock_driver, 'Test Accessory 1', aid=2)
+    acc_2 = Accessory(mock_driver, 'Test Accessory 2', aid=acc_1.aid)
     bridge.add_accessory(acc_1)
     with pytest.raises(ValueError):
         bridge.add_accessory(acc_2)

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -1,58 +1,71 @@
 """Tests for pyhap.accessory."""
+from unittest.mock import patch
+
 import pytest
 
-import pyhap.accessory as accessory
-import pyhap.loader as loader
+from pyhap.accessory import Accessory, Bridge
+from pyhap.accessory_driver import AccessoryDriver
+from pyhap.const import STANDALONE_AID
+
+with patch('pyhap.accessory_driver.HAPServer'), \
+        patch('pyhap.accessory_driver.Zeroconf'):
+    DRIVER = AccessoryDriver()
 
 
-class TestAccessory:
+# #### Accessory ####
+# ###################
 
-    def test_init(self):
-        accessory.Accessory('Test Accessory')
-
-    def test_publish_no_broker(self):
-        acc = accessory.Accessory('Test Accessory')
-        service = loader.get_loader().get_service('TemperatureSensor')
-        char = service.get_characteristic('CurrentTemperature')
-        acc.add_service(service)
-        char.set_value(25, should_notify=True)
-
-    def test_set_services_compatible(self):
-        """Test deprecated method _set_services."""
-        class A(accessory.Accessory):
-            def _set_services(self):
-                super()._set_services()
-                s = loader.get_loader().get_service("TemperatureSensor")
-                self.add_service(s)
-                assert self.get_service("AccessoryInformation") is not None
-        a = A("Test Accessory")
-        assert a.get_service("TemperatureSensor") is not None
+def test_init():
+    Accessory(DRIVER, 'Test Accessory')
 
 
-class TestBridge(TestAccessory):
+def test_publish_no_broker():
+    acc = Accessory(DRIVER, 'Test Accessory')
+    service = acc.driver.loader.get_service('TemperatureSensor')
+    char = service.get_characteristic('CurrentTemperature')
+    acc.add_service(service)
+    char.set_value(25, should_notify=True)
 
-    def test_init(self):
-        accessory.Bridge('Test Bridge')
 
-    def test_add_accessory(self):
-        bridge = accessory.Bridge('Test Bridge')
-        acc = accessory.Accessory('Test Accessory', aid=2)
+def test_set_services_compatible():
+    """Test deprecated method _set_services."""
+    class Acc(Accessory):
+        def _set_services(self):
+            super()._set_services()
+            serv = self.driver.loader.get_service('TemperatureSensor')
+            self.add_service(serv)
+    acc = Acc(DRIVER, 'Test Accessory')
+    assert acc.get_service('AccessoryInformation') is not None
+    assert acc.get_service('TemperatureSensor') is not None
+
+
+# #### Bridge ####
+# ################
+
+def test_init_bridge():
+    Bridge(DRIVER, 'Test Bridge')
+
+
+def test_add_accessory():
+    bridge = Bridge(DRIVER, 'Test Bridge')
+    acc = Accessory(DRIVER, 'Test Accessory', aid=2)
+    bridge.add_accessory(acc)
+    acc2 = Accessory(DRIVER, 'Test Accessory 2')
+    bridge.add_accessory(acc2)
+    assert acc2.aid != STANDALONE_AID and acc2.aid != acc.aid
+
+
+def test_n_add_accessory_bridge_aid():
+    bridge = Bridge(DRIVER, 'Test Bridge')
+    acc = Accessory(DRIVER, 'Test Accessory', aid=STANDALONE_AID)
+    with pytest.raises(ValueError):
         bridge.add_accessory(acc)
-        acc2 = accessory.Accessory('Test Accessory 2')
-        bridge.add_accessory(acc2)
-        assert acc2.aid != accessory.STANDALONE_AID and acc2.aid != acc.aid
 
-    def test_n_add_accessory_bridge_aid(self):
-        bridge = accessory.Bridge('Test Bridge')
-        acc = accessory.Accessory(
-            'Test Accessory', aid=accessory.STANDALONE_AID)
-        with pytest.raises(ValueError):
-            bridge.add_accessory(acc)
 
-    def test_n_add_accessory_dup_aid(self):
-        bridge = accessory.Bridge('Test Bridge')
-        acc_1 = accessory.Accessory('Test Accessory 1', aid=2)
-        acc_2 = accessory.Accessory('Test Accessory 2', aid=acc_1.aid)
-        bridge.add_accessory(acc_1)
-        with pytest.raises(ValueError):
-            bridge.add_accessory(acc_2)
+def test_n_add_accessory_dup_aid():
+    bridge = Bridge(DRIVER, 'Test Bridge')
+    acc_1 = Accessory(DRIVER, 'Test Accessory 1', aid=2)
+    acc_2 = Accessory(DRIVER, 'Test Accessory 2', aid=acc_1.aid)
+    bridge.add_accessory(acc_1)
+    with pytest.raises(ValueError):
+        bridge.add_accessory(acc_2)

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -1,7 +1,6 @@
 """Tests for pyhap.accessory_driver."""
-import os
 import tempfile
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 import pytest
 
@@ -9,52 +8,46 @@ from pyhap.accessory import Accessory, AsyncAccessory, STANDALONE_AID
 from pyhap.accessory_driver import AccessoryDriver
 
 
-@patch("pyhap.accessory_driver.AccessoryDriver.persist")
-@patch("pyhap.accessory_driver.HAPServer", new=Mock())
-def test_auto_add_aid_mac(_persist_mock):
-    acc = Accessory("Test Accessory")
-    driver = AccessoryDriver(acc, 51234, "192.168.1.1", "test.accessory")
+def test_auto_add_aid_mac():
+    with patch('pyhap.accessory_driver.HAPServer'):
+        driver = AccessoryDriver(port=51234, address='192.168.1.1',
+                                 persist_file='test.accessory')
+    acc = Accessory(driver, 'Test Accessory')
+    with patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+        driver.add_accessory(acc)
     assert acc.aid == STANDALONE_AID
     assert driver.state.mac is not None
 
 
-@patch("pyhap.accessory_driver.AccessoryDriver.persist")
-@patch("pyhap.accessory_driver.HAPServer", new=Mock())
-def test_not_standalone_aid(_persist_mock):
-    acc = Accessory("Test Accessory", aid=STANDALONE_AID + 1)
+def test_not_standalone_aid():
+    with patch('pyhap.accessory_driver.HAPServer'):
+        driver = AccessoryDriver(port=51234, address='192.168.1.1',
+                                 persist_file='test.accessory')
+    with patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+        acc = Accessory(driver, 'Test Accessory', aid=STANDALONE_AID + 1)
     with pytest.raises(ValueError):
-        AccessoryDriver(acc, 51234, "192.168.1.1", "test.accessory")
+        driver.add_accessory(acc)
 
 
-@patch("pyhap.accessory_driver.HAPServer", new=Mock())
 def test_persist_load():
-    def get_acc():
-        return Accessory("Test Accessory")
-    fp = tempfile.NamedTemporaryFile(mode="r+")
-    persist_file = fp.name
-    fp.close()
-    try:
-        # Create driver - state gets stored
-        driver = AccessoryDriver(get_acc(), 51234, persist_file=persist_file)
-        pk = driver.state.public_key
-        # Re-start driver with a "new" accessory. State gets loaded into
-        # the new accessory.
-        driver_new = AccessoryDriver(get_acc(), 51234, persist_file=persist_file)
-        # Check pk is the same, i.e. that the state is indeed loaded.
-        assert driver_new.state.public_key == pk
-    finally:
-        os.remove(persist_file)
+    with tempfile.NamedTemporaryFile(mode='r+') as file:
+        with patch('pyhap.accessory_driver.HAPServer'):
+            driver = AccessoryDriver(port=51234, persist_file=file.name)
+            driver.persist()
+            pk = driver.state.public_key
+            # Re-start driver with a "new" accessory. State gets loaded into
+            # the new accessory.
+            driver = AccessoryDriver(port=51234, persist_file=file.name)
+            driver.load()
+    assert driver.state.public_key == pk
 
 
-@patch("pyhap.accessory_driver.Zeroconf", new=Mock())
-@patch("pyhap.accessory_driver.AccessoryDriver.persist")
-@patch("pyhap.accessory_driver.HAPServer", new=Mock())
-def test_start_stop_sync_acc(_persist):
+def test_start_stop_sync_acc():
     class Acc(Accessory):
         running = True
 
         def run(self):
-            while self.run_sentinel.wait(0):
+            while self.driver.stop_event.wait(0):
                 pass
             self.running = False
             driver.stop()
@@ -62,16 +55,17 @@ def test_start_stop_sync_acc(_persist):
         def setup_message(self):
             pass
 
-    acc = Acc("TestAcc")
-    driver = AccessoryDriver(acc, 51234, persist_file="foo")
+    with patch('pyhap.accessory_driver.HAPServer'), \
+            patch('pyhap.accessory_driver.Zeroconf'):
+        driver = AccessoryDriver(port=51234, persist_file="foo")
+    acc = Acc(driver, 'TestAcc')
+    with patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+        driver.add_accessory(acc)
     driver.start()
     assert not acc.running
 
 
-@patch("pyhap.accessory_driver.Zeroconf", new=Mock())
-@patch("pyhap.accessory_driver.AccessoryDriver.persist")
-@patch("pyhap.accessory_driver.HAPServer", new=Mock())
-def test_start_stop_async_acc(_persist):
+def test_start_stop_async_acc():
     class Acc(AsyncAccessory):
 
         @AsyncAccessory.run_at_interval(0)
@@ -81,7 +75,11 @@ def test_start_stop_async_acc(_persist):
         def setup_message(self):
             pass
 
-    acc = Acc("TestAcc")
-    driver = AccessoryDriver(acc, 51234, persist_file="foo")
+    with patch('pyhap.accessory_driver.HAPServer'), \
+            patch('pyhap.accessory_driver.Zeroconf'):
+        driver = AccessoryDriver(port=51234, persist_file='foo')
+    acc = Acc(driver, 'TestAcc')
+    with patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+        driver.add_accessory(acc)
     driver.start()
     assert driver.loop.is_closed()

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -9,28 +9,25 @@ from pyhap.state import State
 import pyhap.encoder as encoder
 
 
-class TestAccessoryEncoder(object):
-    """Tests for AccessoryEncoder."""
+def test_persist_and_load():
+    """Stores an Accessory and then loads the stored state into another
+    Accessory. Tests if the two accessories have the same property values.
+    """
+    mac = generate_mac()
+    _pk, sample_client_pk = ed25519.create_keypair()
+    state = State(mac=mac)
+    state.add_paired_client(uuid.uuid1(), sample_client_pk.to_bytes())
 
-    def test_persist_and_load(self):
-        """Stores an Accessory and then loads the stored state into another
-        Accessory. Tests if the two accessories have the same property values.
-        """
-        mac = generate_mac()
-        _pk, sample_client_pk = ed25519.create_keypair()
-        state = State(mac=mac)
-        state.add_paired_client(uuid.uuid1(), sample_client_pk.to_bytes())
+    config_loaded = State()
+    config_loaded.config_version += 2  # change the default state.
+    enc = encoder.AccessoryEncoder()
+    with tempfile.TemporaryFile(mode="r+") as fp:
+        enc.persist(fp, state)
+        fp.seek(0)
+        enc.load_into(fp, config_loaded)
 
-        config_loaded = State()
-        config_loaded.config_version += 2  # change the default state.
-        enc = encoder.AccessoryEncoder()
-        with tempfile.TemporaryFile(mode="r+") as fp:
-            enc.persist(fp, state)
-            fp.seek(0)
-            enc.load_into(fp, config_loaded)
-
-        assert state.mac == config_loaded.mac
-        assert state.private_key == config_loaded.private_key
-        assert state.public_key == config_loaded.public_key
-        assert state.config_version == config_loaded.config_version
-        assert state.paired_clients == config_loaded.paired_clients
+    assert state.mac == config_loaded.mac
+    assert state.private_key == config_loaded.private_key
+    assert state.public_key == config_loaded.public_key
+    assert state.config_version == config_loaded.config_version
+    assert state.paired_clients == config_loaded.paired_clients

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,10 +1,9 @@
 """Tests for pyhap.loader."""
 import pytest
 
-from pyhap import CHARACTERISTICS_FILE, SERVICES_FILE
 from pyhap.characteristic import Characteristic
 from pyhap.service import Service
-from pyhap.loader import get_loader, Loader
+from pyhap.loader import Loader
 
 
 def test_loader_char():
@@ -62,18 +61,3 @@ def test_loader_service_error():
         loader.serv_types['Service'] = case
         with pytest.raises(KeyError):
             loader.get_service('Service')
-
-
-def test_get_loader():
-    """Test if method returns the preloaded loader object."""
-    loader = get_loader()
-    assert isinstance(loader, Loader)
-    assert loader.char_types is not ({} or None)
-    assert loader.serv_types is not ({} or None)
-
-    loader2 = Loader(path_char=CHARACTERISTICS_FILE,
-                     path_service=SERVICES_FILE)
-    assert loader.char_types == loader2.char_types
-    assert loader.serv_types == loader2.serv_types
-
-    assert get_loader() == loader

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,9 +1,10 @@
 """Tests for pyhap.loader."""
 import pytest
 
+from pyhap import CHARACTERISTICS_FILE, SERVICES_FILE
 from pyhap.characteristic import Characteristic
 from pyhap.service import Service
-from pyhap.loader import Loader
+from pyhap.loader import get_loader, Loader
 
 
 def test_loader_char():
@@ -61,3 +62,18 @@ def test_loader_service_error():
         loader.serv_types['Service'] = case
         with pytest.raises(KeyError):
             loader.get_service('Service')
+
+
+def test_get_loader():
+    """Test if method returns the preloaded loader object."""
+    loader = get_loader()
+    assert isinstance(loader, Loader)
+    assert loader.char_types is not ({} or None)
+    assert loader.serv_types is not ({} or None)
+
+    loader2 = Loader(path_char=CHARACTERISTICS_FILE,
+                     path_service=SERVICES_FILE)
+    assert loader.char_types == loader2.char_types
+    assert loader.serv_types == loader2.serv_types
+
+    assert get_loader() == loader

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ basepython = {env:PYTHON3_PATH:python3}
 deps =
   -r{toxinidir}/requirements_test.txt
 commands =
-  flake8 pyhap tests --ignore=D10,D205,D4,E501 --exclude=pyhap/accessories/*
+  flake8 pyhap tests --ignore=D10,D205,D4,E501
 
 [testenv:pylint]
 basepython = {env:PYTHON3_PATH:python3}
@@ -41,7 +41,7 @@ deps =
   -r{toxinidir}/requirements_all.txt
   -r{toxinidir}/requirements_test.txt
 commands =
-  pylint pyhap --disable=missing-docstring,empty-docstring,invalid-name,fixme
+  pylint pyhap tests --disable=missing-docstring,empty-docstring,invalid-name,fixme
 
 
 [testenv:doc-errors]
@@ -51,6 +51,6 @@ deps =
   -r{toxinidir}/requirements_all.txt
   -r{toxinidir}/requirements_test.txt
 commands =
-  flake8 pyhap tests --select=D10,D205,D4,E501 --exclude=pyhap/accessories/*
+  flake8 pyhap tests --select=D10,D205,D4,E501
   pylint pyhap --disable=all --enable=missing-docstring,empty-docstring
   # pydocstyle pyhap tests


### PR DESCRIPTION
During my improvement PR's I noticed that we assign may things to each accessory although they are only needed once (at the driver level). Especially for bridged accessories that is mostly unnecessary. This PR should be a first step in reversing this behavior.

Instead of assigning the accessory to the driver, I think that I would make much more sense to assign the driver to each accessory and later add the top level one to the driver.

### To-Do
- [x] Remove `accessory.set_sentinel`
- [x] Use `driver.run_sentinel`, `driver.aio_stop_event` and `driver.event_loop`
- [x] ~~Maybe: Assign `keys`, `pincode`, `mac` to driver instead.~~
- [x] Save loader in the driver.

**Note**: All these changes assume that we stick to the current version, where one driver only handles one top level accessory.

@ikalchev What do you think this?