### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+
+## [2.0.0] - 2018-05-04
+
 ### Added
 - New helper methods to run the `run` method repeatedly, until the driver is stopped. `Accessory.repeat(time)` or `AsyncAccessory.repeat(time)`. [#74](https://github.com/ikalchev/HAP-python/pull/74)
 - New helper method `service.configure_char`. Shortcut to configuring a characteristic. [#84](https://github.com/ikalchev/HAP-python/pull/84)

--- a/pyhap/__init__.py
+++ b/pyhap/__init__.py
@@ -6,7 +6,7 @@ _RESOURCE_DIR = os.path.join(_ROOT, "resources")
 CHARACTERISTICS_FILE = os.path.join(_RESOURCE_DIR, "characteristics.json")
 SERVICES_FILE = os.path.join(_RESOURCE_DIR, "services.json")
 
-HAP_PYTHON_VERSION = (1, 1, 9)
+HAP_PYTHON_VERSION = (2, 0, 0)
 """
 HAP-python current version.
 """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="HAP-python",
     description="HomeKit Accessory Protocol implementation in python3",
     author="Ivan Kalchev",
-    version="1.1.9",
+    version="2.0.0",
     url="https://github.com/ikalchev/HAP-python.git",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I'm not sure which version you want to go to, but I assumed from the deprecated notes that it should be `2.0.0`.

It would be really great if you could do the release soon. I could help by creating the merge PR once this (and maybe #107) is/are merged.