### PR TITLE
Remove "accessories" sub-package from setup.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,9 @@ import signal
 import time
 import random
 
-from pyhap.accessories.TemperatureSensor import TemperatureSensor
+# The below package can be found in the HAP-python repository under pyhap/accessories
+from TemperatureSensor import TemperatureSensor
+
 from pyhap.accessory import Bridge
 from pyhap.accessory_driver import AccessoryDriver
 import pyhap.loader as loader
@@ -27,7 +29,7 @@ def get_bridge():
     bridge.add_accessory(temp_sensor2)
 
     # Uncomment if you have RPi module and want a LED LightBulb service on pin 16.
-    # from pyhap.accessories.LightBulb import LightBulb
+    # from accessories.LightBulb import LightBulb
     # bulb = LightBulb("Desk LED", pin=16)
     # bridge.add_accessory(bulb)
     return bridge

--- a/pyhap/__init__.py
+++ b/pyhap/__init__.py
@@ -6,7 +6,7 @@ _RESOURCE_DIR = os.path.join(_ROOT, "resources")
 CHARACTERISTICS_FILE = os.path.join(_RESOURCE_DIR, "characteristics.json")
 SERVICES_FILE = os.path.join(_RESOURCE_DIR, "services.json")
 
-HAP_PYTHON_VERSION = (2, 0, 0)
+HAP_PYTHON_VERSION = (2, 0, 1)
 """
 HAP-python current version.
 """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="HAP-python",
     description="HomeKit Accessory Protocol implementation in python3",
     author="Ivan Kalchev",
-    version="2.0.0",
+    version="2.0.1",
     url="https://github.com/ikalchev/HAP-python.git",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -18,7 +18,6 @@ setup(
     license="Apache-2.0",
     packages=[
         "pyhap",
-        "pyhap.accessories"
     ],
     install_requires=[
         "curve25519-donna",


### PR DESCRIPTION
It is causing the setup.py to display errors on pip install.