### PR TITLE
Small changes - Accessory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Typo in log message in `accessory_driver.stop`. [#112](https://github.com/ikalchev/HAP-python/pull/112)
 
+### Breaking Changes
+- Removed unused method `accessory.create`. [#117](https://github.com/ikalchev/HAP-python/pull/117)
+- Removed `iid_manager` and `setup_id` parameter from `accessory` and `bridge` `init` calls. [#117](https://github.com/ikalchev/HAP-python/pull/117)
+
 ### Developers
 - The `driver` event loop name changed from `event_loop` to `loop`. [#107](https://github.com/ikalchev/HAP-python/pull/107)
 

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -31,13 +31,7 @@ class Accessory:
 
     category = CATEGORY_OTHER
 
-    @classmethod
-    def create(cls, display_name, pincode, aid=STANDALONE_AID):
-        mac = util.generate_mac()
-        return cls(display_name, aid=aid, mac=mac, pincode=pincode)
-
-    def __init__(self, display_name, aid=None, mac=None, pincode=None,
-                 iid_manager=None, setup_id=None):
+    def __init__(self, display_name, aid=None, mac=None, pincode=None):
         """Initialise with the given properties.
 
         :param display_name: Name to be displayed in the Home app.
@@ -71,7 +65,7 @@ class Accessory:
         self.config_version = 2
         self.reachable = True
         self._pincode = pincode
-        self._setup_id = setup_id
+        self._setup_id = None
         self.driver = None
         # threading.Event that gets set when the Accessory should stop.
         self.run_sentinel = None
@@ -83,7 +77,7 @@ class Accessory:
         self.public_key = vk
         self.paired_clients = {}
         self.services = []
-        self.iid_manager = iid_manager or IIDManager()
+        self.iid_manager = IIDManager()
 
         self.add_info_service()
 
@@ -431,14 +425,12 @@ class Bridge(AsyncAccessory):
 
     category = CATEGORY_BRIDGE
 
-    def __init__(self, display_name, mac=None, pincode=None,
-                 iid_manager=None, setup_id=None):
-        aid = STANDALONE_AID
+    def __init__(self, display_name, mac=None, pincode=None):
         # A Bridge cannot be Bridge, hence talks directly to HAP clients.
         # Thus, we need a mac.
         mac = mac or util.generate_mac()
-        super().__init__(display_name, aid=aid, mac=mac, pincode=pincode,
-                         iid_manager=iid_manager, setup_id=setup_id)
+        super().__init__(display_name, aid=STANDALONE_AID, mac=mac,
+                         pincode=pincode)
         self.accessories = {}  # aid: acc
 
     def set_sentinel(self, run_sentinel, aio_stop_event, loop):

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -487,12 +487,7 @@ class Bridge(AsyncAccessory):
 
         .. seealso:: Accessory.to_HAP
         """
-        hap_rep = [super().to_HAP()]
-
-        for acc in self.accessories.values():
-            hap_rep.append(acc.to_HAP())
-
-        return hap_rep
+        return [acc.top_HAP() for acc in (super(), *self.accessories.values())]
 
     def get_characteristic(self, aid, iid):
         """.. seealso:: Accessory.to_HAP

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -106,8 +106,8 @@ class AccessoryDriver:
 
     NUM_EVENTS_BEFORE_STATS = 100
 
-    def __init__(self, accessory, port, address=None, persist_file="accessory.state",
-                 encoder=None):
+    def __init__(self, accessory, port, address=None,
+                 persist_file='accessory.state', encoder=None):
         """
         :param accessory: The `Accessory` to be managed by this driver. The `Accessory`
             must have the standalone AID (`pyhap.accessory.STANDALONE_AID`). If the


### PR DESCRIPTION
### Changes
- Removed unused method `accessory.create`.
- Removed `iid_manager` and `setup_id` parameter from `accessory` and `bridge` `init` calls.
- Improved `accessory.to_HAP()`

In theory this is a breaking change. However it's not very likely many people have used those parameters to begin with since the defaults are quite fine. Therefor this shouldn't be an issue.

Some changes are extracted from #104. I didn't wanted to just propose a single new line ;)
In addition this will help keep the other PR clean.