### PR TITLE
Fix typo in bridge.to_HAP

### DIFF
--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -479,7 +479,7 @@ class Bridge(AsyncAccessory):
 
         .. seealso:: Accessory.to_HAP
         """
-        return [acc.top_HAP() for acc in (super(), *self.accessories.values())]
+        return [acc.to_HAP() for acc in (super(), *self.accessories.values())]
 
     def get_characteristic(self, aid, iid):
         """.. seealso:: Accessory.to_HAP


### PR DESCRIPTION
This typo was limited to the **`dev`** branch. No need to update **`master`**.