### PR TITLE
Changes to organization files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ lib64
 pyvenv.cfg
 share
 
+# pip
+pip-selfcheck.json
+
 # HAP-python-generated files
 accessory.pickle
 accessory.state

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+cdce8p
+jslay88
+Ivan Kalchev <ikalchev> - Maintainer of the library
+Lee Marlow <lmarlow>
+Matthew Schinckel <schinckel>
+Miroslav Kudrnac <mkudrnac>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Sections
 
 ### Developers
 - Removed `acc.set_driver()` and `acc.set_sentinel()` methods. `acc.run_sentinel`, `acc.aio_stop_event` and `acc.loop` are now accessed through `acc.driver.xxx`. `run_sentinel` is changed to `stop_event`. [#105](https://github.com/ikalchev/HAP-python/pull/105)
+- Added scripts for `setup` and `release`.  [#125](https://github.com/ikalchev/HAP-python/pull/125)
 
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,60 @@
+HAP-python is licensed under the Apache License, version 2.0.
+
+This package/repository contains code from the HAP-python project as well as
+some open-source works.
+
+File Copyrights
+===============
+
+All fines not explicitly mentioned below
+    What: HAP-python
+    Source URL: https://github.com/ikalchev/HAP-python
+    Copyright: HAP-python Authors (see AUTHORS file)
+    License: Apache License 2.0
+    License text: See below
+
+setup.py
+    Inspired from: Home Assistant [1]
+    Original file:
+      https://github.com/home-assistant/home-assistant/blob/master/setup.py
+
+scripts/release
+    Inspired from: Home Assistant [1]
+    File: script/release
+      https://github.com/home-assistant/home-assistant/blob/master/script/release
+
+scripts/setup
+    Inspired from: Home Assistant [1]
+    File: script/setup
+      https://github.com/home-assistant/home-assistant/blob/master/script/setup
+
+Credit
+======
+
+Some HAP know-how
+    What: HAP-NodeJS
+    Source URL: https://github.com/KhaosT/HAP-NodeJS
+    Copyright: Khaos Tian
+    License: Apache License 2.0
+    License URL: https://github.com/KhaosT/HAP-NodeJS/blob/master/LICENSE
+
+Some Async know-how
+    What: Home Assistant [1]
+
+HomeKit Accessory Protocol Specification
+  Source URL: https://developer.apple.com/homekit/specification/
+
+Footnotes
+=========
+
+[1] Home Assistant
+    Source URL: https://github.com/home-assistant/home-assistant
+    Copyright: The Home Assistant Authors
+    License: Apache License 2.0
+    License URL: https://github.com/home-assistant/home-assistant/blob/dev/LICENSE.md
+
+===============================================================================
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../../'))
-from pyhap import HAP_PYTHON_VERSION
+from pyhap.const import __version__
 
 
 # -- Project information -----------------------------------------------------
@@ -27,7 +27,7 @@ author = 'Ivan Kalchev'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '.'.join(map(str, HAP_PYTHON_VERSION))
+release = '.'.join(map(str, __version__))
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyhap/__init__.py
+++ b/pyhap/__init__.py
@@ -6,11 +6,6 @@ _RESOURCE_DIR = os.path.join(_ROOT, "resources")
 CHARACTERISTICS_FILE = os.path.join(_RESOURCE_DIR, "characteristics.json")
 SERVICES_FILE = os.path.join(_RESOURCE_DIR, "services.json")
 
-HAP_PYTHON_VERSION = (2, 1, 0)
-"""
-HAP-python current version.
-"""
-
 
 # Flag if QR Code dependencies are installed.
 # Installation with `pip install HAP-python[QRCode]`.

--- a/pyhap/const.py
+++ b/pyhap/const.py
@@ -1,4 +1,10 @@
 """This module contains constants used by other modules."""
+MAJOR_VERSION = 2
+MINOR_VERSION = 1
+PATCH_VERSION = 0
+__short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
+__version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
+REQUIRED_PYTHON_VER = (3, 5)
 
 # ### Misc ###
 STANDALONE_AID = 1  # Standalone accessory ID (i.e. not bridged)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-flake8-docstrings
 flake8
+flake8-docstrings
 pydocstyle
 pylint
 pytest

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pylint
 pytest
 pytest-cov
 pytest-timeout>=1.2.1
+tox

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Install missing dependencies
+if [ -z "$(python3 -m pip list | grep 'wheel')" ]; then
+	python3 -m pip install wheel
+fi
+if [ -z "$(python3 -m pip list | grep 'twine')" ]; then
+	python3 -m pip install twine
+fi
+
+echo "====================================="
+echo "=   Generation source distribution  ="
+echo "====================================="
+python3 setup.py sdist
+
+echo "===================================="
+echo "=   Generation build distribution  ="
+echo "===================================="
+python3 setup.py bdist_wheel
+
+echo "====================="
+echo "=   Upload to pypi  ="
+echo "====================="
+python3 -m twine upload dist/* --skip-existing

--- a/scripts/release
+++ b/scripts/release
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Run to build distribution packages and upload them to pypi
 
 # Stop on errors
 set -e

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "=============================="
+echo "=   Installing dependencies  ="
+echo "=============================="
+pip install -e .[qrcode]
+
+echo "==================================="
+echo "=   Installing test dependencies  ="
+echo "==================================="
+python3 -m pip install tox
+python3 -m pip install -r requirements_test.txt

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Setup development environment
 
 # Stop on errors
 set -e
@@ -13,5 +14,4 @@ pip install -e .[qrcode]
 echo "==================================="
 echo "=   Installing test dependencies  ="
 echo "==================================="
-python3 -m pip install tox
 python3 -m pip install -r requirements_test.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,39 @@
 [metadata]
-description-file = README.md
+license      = Apache License 2.0
+license_file = LICENSE
+author       = HAP-python Authors
+maintainer   = Ivan Kalchev
+platforms  = any
+description = HomeKit Accessory Protocol implementation in python3
+keywords = homekit, home, automation, hap-python
+classifier = 
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Topic :: Home Automation
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+packages = pyhap
+install_requires =
+    curve25519-donna
+    ed25519
+    pycryptodome
+    tlslite-ng
+    zeroconf
+
+[options.extras_require]
+QRCode =
+    base36
+    pyqrcode
+
+[tool:pytest]
+testpaths = tests
+
 [pycodestyle]
 max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,26 @@
 from setuptools import setup
 
+import pyhap.const as pyhap_const
+
+
+PROJECT_NAME = 'HAP-python'
+URL = 'https://github.com/ikalchev/{}'.format(PROJECT_NAME)
+PROJECT_URLS = {
+    'Bug Reports': '{}/issues'.format(URL),
+    'Documentation': 'http://hap-python.readthedocs.io/en/latest/',
+    'Source': '{}/tree/master'.format(URL),
+}
+
+PYPI_URL = 'https://pypi.python.org/pypi/{}'.format(PROJECT_NAME)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(URL, pyhap_const.__version__)
+
+MIN_PY_VERSION = '.'.join(map(str, pyhap_const.REQUIRED_PYTHON_VER))
+
 setup(
-    name="HAP-python",
-    description="HomeKit Accessory Protocol implementation in python3",
-    author="Ivan Kalchev",
-    version="2.1.0",
-    url="https://github.com/ikalchev/HAP-python.git",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
-        "Topic :: Home Automation",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: Apache Software License",
-        "Intended Audience :: Developers",
-    ],
-    license="Apache-2.0",
-    packages=[
-        "pyhap",
-    ],
-    install_requires=[
-        "curve25519-donna",
-        "ed25519",
-        "pycryptodome",
-        "tlslite-ng",
-        "zeroconf",
-    ],
-    extras_require={
-        'QRCode': [
-            'base36',
-            'pyqrcode',
-        ],
-        "dev": [
-            "pytest",
-            "tox",
-        ],
-    },
-    package_data={
-        "pyhap": ["resources/*"],
-    }
+    name=PROJECT_NAME,
+    version=pyhap_const.__version__,
+    url=URL,
+    project_urls=PROJECT_URLS,
+    download_url=DOWNLOAD_URL,
+    python_requires='>={}'.format(MIN_PY_VERSION),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,53 +4,53 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
-  -r{toxinidir}/requirements_test.txt
+    -r{toxinidir}/requirements_test.txt
 commands =
-  pytest --timeout=2 --cov=pyhap --cov-report= {posargs:pyhap tests}
+    pytest --timeout=2 --cov --cov-report= {posargs}
 
 [testenv:temperature]
 basepython = python3.6
 deps =
-  -r{toxinidir}/requirements_all.txt
+    -r{toxinidir}/requirements_all.txt
 commands =
-  python main.py
+    python main.py
 
 [testenv:docs]
 changedir = docs
 deps =
-  -r{toxinidir}/requirements_docs.txt
+    -r{toxinidir}/requirements_docs.txt
 commands =
-  make clean
-  sphinx-build -W -b html source {envtmpdir}/html
+    make clean
+    sphinx-build -W -b html source {envtmpdir}/html
 whitelist_externals=
-  /usr/bin/make
-  make
+    /usr/bin/make
+    make
 
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}
 deps =
-  -r{toxinidir}/requirements_test.txt
+    -r{toxinidir}/requirements_test.txt
 commands =
-  flake8 pyhap tests --ignore=D10,D205,D4,E501
+    flake8 pyhap tests --ignore=D10,D205,D4,E501
 
 [testenv:pylint]
 basepython = {env:PYTHON3_PATH:python3}
 ignore_errors = True
 deps =
-  -r{toxinidir}/requirements_all.txt
-  -r{toxinidir}/requirements_test.txt
+    -r{toxinidir}/requirements_all.txt
+    -r{toxinidir}/requirements_test.txt
 commands =
-  pylint pyhap tests --disable=missing-docstring,empty-docstring,invalid-name,fixme
+    pylint pyhap tests --disable=missing-docstring,empty-docstring,invalid-name,fixme
 
 
 [testenv:doc-errors]
 basepython = {env:PYTHON3_PATH:python3}
 ignore_errors = True
 deps =
-  -r{toxinidir}/requirements_all.txt
-  -r{toxinidir}/requirements_test.txt
+    -r{toxinidir}/requirements_all.txt
+    -r{toxinidir}/requirements_test.txt
 commands =
-  flake8 pyhap tests --select=D10,D205,D4,E501
-  pylint pyhap --disable=all --enable=missing-docstring,empty-docstring
-  # pydocstyle pyhap tests
+    flake8 pyhap tests --select=D10,D205,D4,E501
+    pylint pyhap --disable=all --enable=missing-docstring,empty-docstring
+    # pydocstyle pyhap tests


### PR DESCRIPTION
Some suggestion on for the overall structure of the `HAP-python` project. The original intend was to add a section to the `LICENSE` file giving credit to other open source projects when code was adopted.
Next I wanted to include the `LICENSE` file in the distribution and I ended out moving almost all static content to `setup.cfg`.

In addition to small style changes (4-space indent for `tox.ini` for better readability), I also added two scripts to simplify setup and release. The later now generates a build distribution as well, not just a source distro.

For `setup`, I modified some files. The `description-file` wasn't included at all, so I removed it (also not really necessary IMO). If you think otherwise, the `long_description` attribute should work. Furthermore I added `keywords` and extended the `classifier`.

## Changes
* Extended use of setup.cfg for static settings
* Moved version to pyhap.const
* Extended license information
* Added authors file
* Added scripts for setup and release

Tested with `setuptools 39.2.0`

## Disclaimer

I'm no legal export, so I can't guaranty that the additions to the `LICENSE` are the best way to go. My inspiration for this change was the `sandstorm` project. In their wiki they have a section [Giving credit to other open source projects](https://github.com/sandstorm-io/sandstorm/wiki/Giving-credit-to-other-open-source-projects) and I looked at their [LICENSE file](https://github.com/sandstorm-io/sandstorm/blob/master/LICENSE).