### PR TITLE
Fix package_data, bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ Sections
 ### Developers
 -->
 
-## [2.2.0] - 2018-05-26
+## [2.2.1] - 2018-05-29
+
+### Fixed
+- Package data is now included again. [#128](https://github.com/ikalchev/HAP-python/pull/128)
+
+
+
+## [2.2.0] - 2018-05-26 - Broken
 
 ### Added
 - Option to pass custom loader object to `driver` with parameter `loader`. [#105](https://github.com/ikalchev/HAP-python/pull/105)

--- a/pyhap/const.py
+++ b/pyhap/const.py
@@ -1,7 +1,7 @@
 """This module contains constants used by other modules."""
 MAJOR_VERSION = 2
 MINOR_VERSION = 2
-PATCH_VERSION = 0
+PATCH_VERSION = 1
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifier =
 
 [options]
 packages = pyhap
+include_package_date = true
 install_requires =
     curve25519-donna
     ed25519


### PR DESCRIPTION
It seems like the `package_data` didn't get included in the wheel `HAP_python-2.2.0-py3-none-any.whl`. It worked for me with the `setuptools==39.2.0` which is why I probably didn't noticed it.

This should fix the issue, since `include_package_data` includes all none `.py` files in the package (`pyhap`) as long as it's specified in the `MANIFEST.in` which is the case.