### PR TITLE
Fix spelling error, bump version to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ Sections
 ### Developers
 -->
 
-## [2.2.1] - 2018-05-29
+## [2.2.2] - 2018-05-29
+
+### Fixed
+- Spelling mistake in `setup.cfg` that caused broken builds. [#130](https://github.com/ikalchev/HAP-python/pull/130)
+
+
+
+## [2.2.1] - 2018-05-29 - Broken
 
 ### Fixed
 - Package data is now included again. [#128](https://github.com/ikalchev/HAP-python/pull/128)

--- a/pyhap/const.py
+++ b/pyhap/const.py
@@ -1,7 +1,7 @@
 """This module contains constants used by other modules."""
 MAJOR_VERSION = 2
 MINOR_VERSION = 2
-PATCH_VERSION = 1
+PATCH_VERSION = 2
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5)

--- a/scripts/release
+++ b/scripts/release
@@ -6,6 +6,14 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+# Remove previous build
+if [ -n "$(ls | grep 'build')" ]; then
+	rm -r build/
+fi
+
+# Upgrade setuptools to the latest version
+python3 -m pip install --upgrade setuptools
+
 # Install missing dependencies
 if [ -z "$(python3 -m pip list | grep 'wheel')" ]; then
 	python3 -m pip install wheel

--- a/scripts/release
+++ b/scripts/release
@@ -8,18 +8,7 @@ cd "$(dirname "$0")/.."
 
 # Remove previous build
 if [ -n "$(ls | grep 'build')" ]; then
-	rm -r build/
-fi
-
-# Upgrade setuptools to the latest version
-python3 -m pip install --upgrade setuptools
-
-# Install missing dependencies
-if [ -z "$(python3 -m pip list | grep 'wheel')" ]; then
-	python3 -m pip install wheel
-fi
-if [ -z "$(python3 -m pip list | grep 'twine')" ]; then
-	python3 -m pip install twine
+  rm -r build/
 fi
 
 echo "====================================="

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifier =
 
 [options]
 packages = pyhap
-include_package_date = true
+include_package_data = true
 install_requires =
     curve25519-donna
     ed25519


### PR DESCRIPTION
Unfortunately I had wrote `date` instead of `data`, which resulted in the wheel being broken again :disappointed:

The upside is that it should work now, which I could test, since I just found out that I had to delete the build directory before I start a new one.