### PR TITLE
Char - ignore duplicate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Sections
 ### Developers
 -->
 
-## [2.2.3] - 2018-10-05
+## [2.x.x] - TBA
 
 ### Added
 - Added `NeoPixelsLightStrip` accessory. [#144](https://github.com/ikalchev/HAP-python/pull/144)
@@ -24,6 +24,7 @@ Sections
 
 ### Changed
 - Spelling fix - executor (accessory_driver). [#159](https://github.com/ikalchev/HAP-python/pull/159)
+- Char.update_client_value now ignores call if value is already set. This could happen during automations. [#162](https://github.com/ikalchev/HAP-python/pull/162)
 
 ### Fixed
 - Updated README. [#138](https://github.com/ikalchev/HAP-python/pull/138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Sections
 
 ### Changed
 - Spelling fix - executor (accessory_driver). [#159](https://github.com/ikalchev/HAP-python/pull/159)
-- Char.update_client_value now ignores call if value is already set. This could happen during automations. [#162](https://github.com/ikalchev/HAP-python/pull/162)
+- Char.client_update_value now ignores call if value is already set. This could happen during automations. [#162](https://github.com/ikalchev/HAP-python/pull/162)
 
 ### Fixed
 - Updated README. [#138](https://github.com/ikalchev/HAP-python/pull/138)

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -206,6 +206,9 @@ class Characteristic:
         """
         logger.debug('client_update_value: %s to %s',
                      self.display_name, value)
+        if self.value == value:
+            logger.debug('ignoring call, value already set')
+            return
         self.value = value
         self.notify()
         if self.setter_callback:

--- a/tests/test_characteristic.py
+++ b/tests/test_characteristic.py
@@ -138,6 +138,19 @@ def test_client_update_value():
     mock_callback.assert_called_with(3)
 
 
+def test_client_update_value_duplicate_value():
+    """Test updating char value with same value with call from driver."""
+    path_notify = 'pyhap.characteristic.Characteristic.notify'
+    char = get_char(PROPERTIES.copy())
+    char.value = 4
+
+    with patch(path_notify) as mock_notify:
+        char.client_update_value(4)
+
+    assert char.value == 4
+    assert mock_notify.called is False
+
+
 def test_notify():
     """Test if driver is notified correctly about a changed characteristic."""
     char = get_char(PROPERTIES.copy())


### PR DESCRIPTION
`HomeKit` automations initiate calls to the server without taking the current value into account. That isn't the case normally and even scenes respect them. I think the best option would be to integrate a check in `client_update_value` if the value is already set and if so ignore that call.

See also: https://github.com/home-assistant/home-assistant/pull/17453

CC: @adrum