### PR TITLE
Revert char ignore duplicate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Sections
 ### Fixed
 - `AcessoryDriver.add_job` now correctly schedules coroutines wrapped in functools.partial.
 
+### Reverted
+- Char.client_update_value no longer ignores duplicate values. Reverts [#162](https://github.com/ikalchev/HAP-python/pull/162). [#166](https://github.com/ikalchev/HAP-python/pull/166)
+
+
 ## [2.3.0] - 2018-10-25
 
 ### Added

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -206,9 +206,6 @@ class Characteristic:
         """
         logger.debug('client_update_value: %s to %s',
                      self.display_name, value)
-        if self.value == value:
-            logger.debug('ignoring call, value already set')
-            return
         self.value = value
         self.notify()
         if self.setter_callback:

--- a/tests/test_characteristic.py
+++ b/tests/test_characteristic.py
@@ -138,19 +138,6 @@ def test_client_update_value():
     mock_callback.assert_called_with(3)
 
 
-def test_client_update_value_duplicate_value():
-    """Test updating char value with same value with call from driver."""
-    path_notify = 'pyhap.characteristic.Characteristic.notify'
-    char = get_char(PROPERTIES.copy())
-    char.value = 4
-
-    with patch(path_notify) as mock_notify:
-        char.client_update_value(4)
-
-    assert char.value == 4
-    assert mock_notify.called is False
-
-
 def test_notify():
     """Test if driver is notified correctly about a changed characteristic."""
     char = get_char(PROPERTIES.copy())


### PR DESCRIPTION
This PR reverts the changes made with #162
As it turns out, there is a reason why sometimes duplicated values are send: Mainly if multiple chars are changed (e.g. changing the color of a light will change the hue and the saturation char).

I think the original PR was a shortcut I shouldn't have taken, sorry for that. Form a Home Assistant perspective there is no need to do another release soon, just for this one. I've reverted to `2.2.2` for now.