### PR TITLE
Temp disable 'update_advertisment' after pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ Sections
 ### Added
 - Added a `asyncio.SafeChildWatcher` as part of `AccessoryDriver.start`.
 - Added `Camera.stop`, which terminates all streaming processes.
+- `AccessoryDriver.safe_mode` parameter. Set with `driver.safe_mode = True` before `driver.start` to disable `update_advertisement` call for `pair` and `unpair`. After unpairing a restart is necessary. [#168](https://github.com/ikalchev/HAP-python/pull/168)
 
 ### Changed
 - The default implementations of the `Camera`'s `start_stream`, `stop_stream` and
 `reconfigure_stream` are now async.
 - The streaming process is started with `asyncio.create_subprocess_exec` instead of
 `subprocess.Popen`
-- Temporary disabled `update_advertisement` call after `pair` and `unpair`. To pair the accessory again after a successful unpair, you need to restart `HAP-python`. [#167](https://github.com/ikalchev/HAP-python/pull/167)
 
 ### Fixed
 - `AcessoryDriver.add_job` now correctly schedules coroutines wrapped in functools.partial.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Sections
 `reconfigure_stream` are now async.
 - The streaming process is started with `asyncio.create_subprocess_exec` instead of
 `subprocess.Popen`
+- Temporary disabled `update_advertisement` call after `pair` and `unpair`. To pair the accessory again after a successful unpair, you need to restart `HAP-python`. [#167](https://github.com/ikalchev/HAP-python/pull/167)
 
 ### Fixed
 - `AcessoryDriver.add_job` now correctly schedules coroutines wrapped in functools.partial.

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -183,6 +183,8 @@ class AccessoryDriver:
         self.sent_events = 0
         self.accumulated_qsize = 0
 
+        self.safe_mode = False
+
         self.mdns_service_info = None
         self.srp_verifier = None
         self.accessory_thread = None
@@ -480,8 +482,8 @@ class AccessoryDriver:
         logger.info("Paired with %s.", client_uuid)
         self.state.add_paired_client(client_uuid, client_public)
         self.persist()
-        # TODO: Figure out why update_advertisement after pairing causes issues
-        # self.update_advertisement()
+        if not self.safe_mode:
+            self.update_advertisement()
         return True
 
     def unpair(self, client_uuid):
@@ -496,8 +498,8 @@ class AccessoryDriver:
         logger.info("Unpairing client %s.", client_uuid)
         self.state.remove_paired_client(client_uuid)
         self.persist()
-        # TODO: Figure out why update_advertisement after unpairing causes issues
-        # self.update_advertisement()
+        if not self.safe_mode:
+            self.update_advertisement()
 
     def setup_srp_verifier(self):
         """Create an SRP verifier for the accessory's info."""

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -482,6 +482,8 @@ class AccessoryDriver:
         logger.info("Paired with %s.", client_uuid)
         self.state.add_paired_client(client_uuid, client_public)
         self.persist()
+        # Safe mode added to avoid error during pairing, see
+        # https://github.com/home-assistant/home-assistant/issues/14567
         if not self.safe_mode:
             self.update_advertisement()
         return True

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -480,7 +480,8 @@ class AccessoryDriver:
         logger.info("Paired with %s.", client_uuid)
         self.state.add_paired_client(client_uuid, client_public)
         self.persist()
-        self.update_advertisement()
+        # TODO: Figure out why update_advertisement after pairing causes issues
+        # self.update_advertisement()
         return True
 
     def unpair(self, client_uuid):
@@ -495,7 +496,8 @@ class AccessoryDriver:
         logger.info("Unpairing client %s.", client_uuid)
         self.state.remove_paired_client(client_uuid)
         self.persist()
-        self.update_advertisement()
+        # TODO: Figure out why update_advertisement after unpairing causes issues
+        # self.update_advertisement()
 
     def setup_srp_verifier(self):
         """Create an SRP verifier for the accessory's info."""


### PR DESCRIPTION
In some cases the pairing doesn't work, because unregister and register of the mDNS service doesn't work as expected. If we remove the call to `update_advertisement` inside the `pair` and `unpair` methods, we eliminate that point of failure. The only drawback is that the user would either need to restart HAP-python after unpairing (that's want I would propose) or the service would need to be discoverable constantly.

Related issues:
https://github.com/home-assistant/home-assistant/issues/17181
https://github.com/home-assistant/home-assistant/issues/14567