### PR TITLE
Accessory unavailability support

### DIFF
--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -79,7 +79,7 @@ class Characteristic:
     """
 
     __slots__ = ('broker', 'display_name', 'properties', 'type_id',
-                 'value', 'getter_callback', 'setter_callback')
+                 'value', 'getter_callback', 'setter_callback', 'hasError')
 
     def __init__(self, display_name, type_id, properties):
         """Initialise with the given properties.
@@ -102,6 +102,7 @@ class Characteristic:
         self.value = self._get_default_value()
         self.getter_callback = None
         self.setter_callback = None
+        self.hasError = False
 
     def __repr__(self):
         """Return the representation of the characteristic."""
@@ -121,6 +122,10 @@ class Characteristic:
 
         :return: Current Characteristic Value
         """
+
+        if self.hasError:
+            raise CharacteristicError()
+
         if self.getter_callback:
             # pylint: disable=not-callable
             self.value = self.to_valid_value(value=self.getter_callback())
@@ -194,6 +199,9 @@ class Characteristic:
         :type should_notify: bool
         """
         logger.debug('set_value: %s to %s', self.display_name, value)
+
+        self.hasError = isinstance(value, Exception)
+
         value = self.to_valid_value(value)
         self.value = value
         if should_notify and self.broker:


### PR DESCRIPTION
It would be nice to be able to mark accessories as unavailable (i.e. having "no response" in HomeKit terms). Related Home Assistant issue: home-assistant/home-assistant#21142.

There's already a property called `reachable` in the `Accessory` class but it doesn't seem to be used. Anyway, it seems like "unreachable" and "no response" are different from HomeKit's point of view: https://github.com/KhaosT/HAP-NodeJS/issues/499#issuecomment-335736097.

HAP-NodeJS does support "no response" and here's how I believe it works:
* [Setting](https://github.com/KhaosT/HAP-NodeJS/blob/d0f92c202e312717829b76c3803c86aa04fa8dc0/lib/Characteristic.js#L310-L311) or [updating](https://github.com/KhaosT/HAP-NodeJS/blob/d0f92c202e312717829b76c3803c86aa04fa8dc0/lib/Characteristic.js#L359-L360) an error as characteristic's value changes its internal state (`status`) and makes `getValue` implementation return the error until it's reset by another set/update.
* HomeKit queries characteristic's value and if the callback gets a non-null error, `status` key of the `response` dictionary is set to non-zero error code: https://github.com/KhaosT/HAP-NodeJS/blob/d0f92c202e312717829b76c3803c86aa04fa8dc0/lib/Accessory.js#L775-L781.

Here's a PR with some explanation: https://github.com/KhaosT/HAP-NodeJS/pull/556.

I tried to mimic this approach and added a boolean flag to `Characteristic` class that's set to `True` if `set_value` is invoked with an `Exception` instance and to `False` otherwise. Then I changed HASS’ `Outlet` accessory to pass an exception in `set_value` if `new_state.state == STATE_UNAVAILABLE`. 

As HAP-Python already sets `response['status']` to `SERVICE_COMMUNICATION_FAILURE` if `Characteristic.getValue` throws a `CharacteristicError`, throwing in `get_value` causes the accessory that contains the characteristic to go "no response" in Home.app.

Unfortunately, this breaks `to_HAP` implementation because it calls `get_value` too. Also, I have no idea how it'd play with `getter_callback`. I have a feeling that it could be implemented much cleaner.

I'd appreciate any ideas & hints!