### PR TITLE
Make it possible to advertise custom service IP and MAC address

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -81,15 +81,13 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
     def __init__(self, accessory, state):
         self.accessory = accessory
         self.state = state
-        hname = socket.gethostname()
-        pubname = hname + '.' if hname.endswith('.local') else hname + '.local.'
 
         adv_data = self._get_advert_data()
         super().__init__(
             '_hap._tcp.local.',
             self.accessory.display_name + '._hap._tcp.local.',
             socket.inet_aton(self.state.address), self.state.port,
-            0, 0, adv_data, pubname)
+            0, 0, adv_data)
 
     def _setup_hash(self):
         setup_hash_material = self.state.setup_id + self.state.mac

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -48,6 +48,7 @@ from pyhap.hsrp import Server as SrpServer
 from pyhap.loader import Loader
 from pyhap.params import get_srp_context
 from pyhap.state import State
+from pyhap import util
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +199,7 @@ class AccessoryDriver:
         self.mdns_service_info = None
         self.srp_verifier = None
 
+        address = address or util.get_local_address()
         advertised_address = advertised_address or address
         self.state = State(address=advertised_address, pincode=pincode, port=port)
 

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -133,7 +133,7 @@ class AccessoryDriver:
 
     def __init__(self, *, address=None, port=51234,
                  persist_file='accessory.state', pincode=None,
-                 encoder=None, loader=None, loop=None,
+                 encoder=None, loader=None, loop=None, mac=None,
                  listen_address=None, advertised_address=None):
         """
         Initialize a new AccessoryDriver object.
@@ -160,6 +160,10 @@ class AccessoryDriver:
 
         :param encoder: The encoder to use when persisting/loading the Accessory state.
         :type encoder: AccessoryEncoder
+
+        :param mac: The MAC address which will be used to identify the accessory.
+            If not given, the driver will try to select a MAC address.
+        :type mac: str
 
         :param listen_address: The local address on the HAPServer will listen.
             If not given, the value of the address parameter will be used.
@@ -204,7 +208,7 @@ class AccessoryDriver:
 
         address = address or util.get_local_address()
         advertised_address = advertised_address or address
-        self.state = State(address=advertised_address, pincode=pincode, port=port)
+        self.state = State(address=advertised_address, mac=mac, pincode=pincode, port=port)
 
         listen_address = listen_address or address
         network_tuple = (listen_address, self.state.port)

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -85,13 +85,13 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
         self.accessory = accessory
         self.state = state
 
-        adv_name = RE_NON_ALPHANUM.sub('', self.accessory.display_name)
+        adv_name = RE_NON_ALPHANUM.sub('-', self.accessory.display_name)
         adv_data = self._get_advert_data()
         super().__init__(
             '_hap._tcp.local.',
-            adv_name + '._hap._tcp.local.',
+            self.accessory.display_name + '._hap._tcp.local.',
             socket.inet_aton(self.state.address), self.state.port,
-            0, 0, adv_data)
+            0, 0, adv_data, adv_name + '.local.')
 
     def _setup_hash(self):
         setup_hash_material = self.state.setup_id + self.state.mac

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -34,7 +34,6 @@ import time
 import threading
 import json
 import queue
-import re
 
 from zeroconf import ServiceInfo, Zeroconf
 
@@ -55,7 +54,6 @@ logger = logging.getLogger(__name__)
 
 CHAR_STAT_OK = 0
 SERVICE_COMMUNICATION_FAILURE = -70402
-RE_NON_ALPHANUM = re.compile(r'[\W_]+', re.UNICODE)
 
 
 def callback(func):
@@ -85,13 +83,12 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
         self.accessory = accessory
         self.state = state
 
-        adv_name = RE_NON_ALPHANUM.sub('-', self.accessory.display_name)
         adv_data = self._get_advert_data()
         super().__init__(
             '_hap._tcp.local.',
             self.accessory.display_name + '._hap._tcp.local.',
             socket.inet_aton(self.state.address), self.state.port,
-            0, 0, adv_data, adv_name + '.local.')
+            0, 0, adv_data)
 
     def _setup_hash(self):
         setup_hash_material = self.state.setup_id + self.state.mac

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -129,7 +129,8 @@ class AccessoryDriver:
 
     def __init__(self, *, address=None, port=51234,
                  persist_file='accessory.state', pincode=None,
-                 encoder=None, loader=None, loop=None):
+                 encoder=None, loader=None, loop=None,
+                 listen_address=None, advertised_address=None):
         """
         Initialize a new AccessoryDriver object.
 
@@ -155,6 +156,15 @@ class AccessoryDriver:
 
         :param encoder: The encoder to use when persisting/loading the Accessory state.
         :type encoder: AccessoryEncoder
+
+        :param listen_address: The local address on the HAPServer will listen.
+            If not given, the value of the address parameter will be used.
+        :type listen_address: str
+
+        :param advertised_address: The address of the HAPServer announced via mDNS.
+            This can be used to announce an external address from behind a NAT.
+            If not given, the value of the address parameter will be used.
+        :type advertised_address: str
         """
         if sys.platform == 'win32':
             self.loop = loop or asyncio.ProactorEventLoop()
@@ -188,8 +198,11 @@ class AccessoryDriver:
         self.mdns_service_info = None
         self.srp_verifier = None
 
-        self.state = State(address=address, pincode=pincode, port=port)
-        network_tuple = (self.state.address, self.state.port)
+        advertised_address = advertised_address or address
+        self.state = State(address=advertised_address, pincode=pincode, port=port)
+
+        listen_address = listen_address or address
+        network_tuple = (listen_address, self.state.port)
         self.http_server = HAPServer(network_tuple, self)
 
     def start(self):

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -34,6 +34,7 @@ import time
 import threading
 import json
 import queue
+import re
 
 from zeroconf import ServiceInfo, Zeroconf
 
@@ -54,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 CHAR_STAT_OK = 0
 SERVICE_COMMUNICATION_FAILURE = -70402
+RE_NON_ALPHANUM = re.compile(r'[\W_]+', re.UNICODE)
 
 
 def callback(func):
@@ -83,10 +85,11 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
         self.accessory = accessory
         self.state = state
 
+        adv_name = RE_NON_ALPHANUM.sub('', self.accessory.display_name)
         adv_data = self._get_advert_data()
         super().__init__(
             '_hap._tcp.local.',
-            self.accessory.display_name + '._hap._tcp.local.',
+            adv_name + '._hap._tcp.local.',
             socket.inet_aton(self.state.address), self.state.port,
             0, 0, adv_data)
 


### PR DESCRIPTION
I would like to make it possible to advertise custom service IP addresses.

This is a requirement for the following use cases: 
- Running HAP (or Home Assistant) behind a NAT, e.g. with Docker.
- Running it on a system with multiple interfaces there the IP and hostname diverge.

The forwarding of the required mDNS packets can be done with an avahi-daemon based gateway, e.g. by using `enable-reflector=yes`.