### PR TITLE
Ensure events are not sent to the initiator client

### DIFF
--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -294,7 +294,7 @@ class Accessory:
 
     # Driver
 
-    def publish(self, value, sender):
+    def publish(self, value, sender, sender_client_addr=None):
         """Append AID and IID of the sender and forward it to the driver.
 
         Characteristics call this method to send updates.
@@ -310,7 +310,7 @@ class Accessory:
             HAP_REPR_IID: self.iid_manager.get_iid(sender),
             HAP_REPR_VALUE: value,
         }
-        self.driver.publish(acc_data)
+        self.driver.publish(acc_data, sender_client_addr)
 
 
 class Bridge(Accessory):

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -200,26 +200,26 @@ class Characteristic:
         if should_notify and self.broker:
             self.notify()
 
-    def client_update_value(self, value):
+    def client_update_value(self, value, sender_client_addr=None):
         """Called from broker for value change in Home app.
 
         Change self.value to value and call callback.
         """
-        logger.debug('client_update_value: %s to %s',
-                     self.display_name, value)
+        logger.debug('client_update_value: %s to %s from client: %s',
+                     self.display_name, value, sender_client_addr)
         self.value = value
-        self.notify()
+        self.notify(sender_client_addr)
         if self.setter_callback:
             # pylint: disable=not-callable
             self.setter_callback(value)
 
-    def notify(self):
+    def notify(self, sender_client_addr=None):
         """Notify clients about a value change. Sends the value.
 
         .. seealso:: accessory.publish
         .. seealso:: accessory_driver.publish
         """
-        self.broker.publish(self.value, self)
+        self.broker.publish(self.value, self, sender_client_addr)
 
     # pylint: disable=invalid-name
     def to_HAP(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ class MockDriver():
     def __init__(self):
         self.loader = Loader()
 
-    def publish(self, data):
+    def publish(self, data, client_addr=None):
         pass
 
     def add_job(self, target, *args):

--- a/tests/test_characteristic.py
+++ b/tests/test_characteristic.py
@@ -137,6 +137,10 @@ def test_client_update_value():
     assert mock_notify.call_count == 2
     mock_callback.assert_called_with(3)
 
+    with patch(path_notify) as mock_notify:
+        char.client_update_value(9, "mock_client_addr")
+        assert char.value == 9
+        mock_notify.assert_called_once_with("mock_client_addr")
 
 def test_notify():
     """Test if driver is notified correctly about a changed characteristic."""
@@ -148,7 +152,12 @@ def test_notify():
 
     with patch.object(char, 'broker') as mock_broker:
         char.notify()
-    mock_broker.publish.assert_called_with(2, char)
+    mock_broker.publish.assert_called_with(2, char, None)
+
+    with patch.object(char, 'broker') as mock_broker:
+        char.notify("mock_client_addr")
+    mock_broker.publish.assert_called_with(2, char, "mock_client_addr")
+
 
 
 def test_to_HAP_numberic():


### PR DESCRIPTION
Clients that made the characteristic change are NOT supposed to get
events
about the characteristic change as it can cause an unexpected HTTP
disconnect (connection
reset by peer) which leads temporary unresponsive accessories and
violates the HAP spec