### PR TITLE
Add logging of exceptions in finish_request

### DIFF
--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -893,6 +893,8 @@ class HAPServer(socketserver.ThreadingMixIn,
         except (OSError, socket.timeout) as e:
             self._handle_sock_timeout(client_address, e)
             logger.debug('Connection timeout')
+        except Exception as e:
+            logger.debug('finish_request: %s', e, exc_info=True)
         finally:
             logger.debug('Cleaning connection to %s', client_address)
             conn_sock = self.connections.pop(client_address, None)


### PR DESCRIPTION
If a request fails with an exception other the socket timeout there
is no information of why, so add debug logging.

To give some background for this change I by accident built the cryptography package against a openssl fork that doesn't support ChaCha20Poly1305, which meant that my home-assistant server just closed all connections when getting requests from my phone without any information in the logs on why.