### PR TITLE
Fix loop on dropped connection

### DIFF
--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -749,7 +749,8 @@ class HAPSocket:
                     self.LENGTH_LENGTH, socket.MSG_WAITALL
                 )
                 if not block_length_bytes:
-                    return result
+                    # Connection likely dropped
+                    return b""
                 # Init. info about the block we just started.
                 # Note we are setting the total length to block_length + mac length
                 self.curr_in_total = \
@@ -778,6 +779,9 @@ class HAPSocket:
                     self.in_count += 1
                     self.curr_in_block = None
                     break
+                elif not actual_len:
+                    # Connection likely dropped
+                    return b""
 
         return result
 


### PR DESCRIPTION
I've been trying to catch this happening for a few months and finally
managed to catch it happening.

<img width="1343" alt="Screen Shot 2020-05-09 at 10 59 49 PM" src="https://user-images.githubusercontent.com/663432/81490533-305eab80-9249-11ea-990a-c0efada19821.png">


Pyhap loop
```
 31.00%  31.00%    5.80s     5.80s   recv (pyhap/hap_server.py:763)
 34.00%  34.00%    1.34s     1.36s   run (zeroconf/__init__.py:1223)
  4.00%   4.00%    1.27s     1.27s   recv (pyhap/hap_server.py:766)
  1.00%   1.00%   0.660s    0.660s   _worker (concurrent/futures/thread.py:78)
  4.00%   4.00%   0.590s    0.590s   recv (pyhap/hap_server.py:769)
  0.00%   0.00%   0.510s    0.510s   recv (pyhap/hap_server.py:768)
  0.00%   0.00%   0.470s    0.470s   recv (pyhap/hap_server.py:749)
  2.00%   2.00%   0.460s    0.460s   recv (pyhap/hap_server.py:762)
  1.00%   1.00%   0.430s    0.430s   recv (pyhap/hap_server.py:765)
  3.00%   3.00%   0.340s    0.340s   recv (pyhap/hap_server.py:767)
  1.00%   1.00%   0.280s    0.280s   recv (pyhap/hap_server.py:742)
```

<img width="342" alt="Screen_Shot_2020-05-09_at_11_27_26_PM" src="https://user-images.githubusercontent.com/663432/81490891-fe4f4880-924c-11ea-9726-59eff14a5e3e.png">
