### PR TITLE
Allow passing in a zeroconf instance.

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -133,7 +133,8 @@ class AccessoryDriver:
     def __init__(self, *, address=None, port=51234,
                  persist_file='accessory.state', pincode=None,
                  encoder=None, loader=None, loop=None, mac=None,
-                 listen_address=None, advertised_address=None, interface_choice=None):
+                 listen_address=None, advertised_address=None, interface_choice=None,
+                 zeroconf_instance=None):
         """
         Initialize a new AccessoryDriver object.
 
@@ -175,6 +176,10 @@ class AccessoryDriver:
 
         :param interface_choice: The zeroconf interfaces to listen on.
         :type InterfacesType: [InterfaceChoice.Default, InterfaceChoice.All]
+
+        :param zeroconf_instance: A Zeroconf instance. When running multiple accessories or
+            bridges a single zeroconf instance can be shared to avoid the overhead
+            of processing the same data multiple times.
         """
         if sys.platform == 'win32':
             self.loop = loop or asyncio.ProactorEventLoop()
@@ -190,7 +195,9 @@ class AccessoryDriver:
 
         self.accessory = None
         self.http_server_thread = None
-        if interface_choice is not None:
+        if zeroconf_instance is not None:
+            self.advertiser = zeroconf_instance
+        elif interface_choice is not None:
             self.advertiser = Zeroconf(interfaces=interface_choice)
         else:
             self.advertiser = Zeroconf()

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -54,6 +54,14 @@ def test_persist_load():
     assert driver.state.public_key == pk
 
 
+def test_external_zeroconf():
+    zeroconf = MagicMock()
+    with patch('pyhap.accessory_driver.HAPServer'), \
+            patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+        driver = AccessoryDriver(port=51234, zeroconf_instance=zeroconf)
+    assert driver.advertiser == zeroconf
+
+
 def test_service_callbacks(driver):
     bridge = Bridge(driver, "mybridge")
     acc = Accessory(driver, 'TestAcc', aid=2)


### PR DESCRIPTION
Home Assistant is now sharing a single `Zeroconf` instance between integrations to avoid the overhead of running multiple instances.  In some cases more than 10 instances were running at a time.

As each instance is listening for updates on the network the overhead can be significant, by sharing a singe instance this problem is mitigated.