### PR TITLE
Add support for accessory unavailability

### DIFF
--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -74,6 +74,18 @@ class Accessory:
         """
         pass
 
+    @property
+    def available(self):
+        """Accessory is available.
+
+        If available is False, get_characteristics will return
+        SERVICE_COMMUNICATION_FAILURE for the accessory which will
+        show as unavailable.
+
+        Expected to be overridden.
+        """
+        return True
+
     def add_info_service(self):
         """Helper method to add the required `AccessoryInformation` service.
 

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -47,7 +47,6 @@ class Accessory:
         self.aid = aid
         self.display_name = display_name
         self.driver = driver
-        self.reachable = True
         self.services = []
         self.iid_manager = IIDManager()
 

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -7,9 +7,13 @@ import pytest
 
 from pyhap.accessory import STANDALONE_AID, Accessory, Bridge
 from pyhap.accessory_driver import AccessoryDriver
-from pyhap.characteristic import (HAP_FORMAT_INT, HAP_PERMISSION_READ,
-                                  PROP_FORMAT, PROP_PERMISSIONS,
-                                  Characteristic)
+from pyhap.characteristic import (
+    HAP_FORMAT_INT,
+    HAP_PERMISSION_READ,
+    PROP_FORMAT,
+    PROP_PERMISSIONS,
+    Characteristic,
+)
 from pyhap.const import HAP_REPR_IID, HAP_REPR_CHARS, HAP_REPR_AID, HAP_REPR_VALUE
 from pyhap.service import Service
 
@@ -19,31 +23,40 @@ CHAR_PROPS = {
 }
 
 
+class UnavailableAccessory(Accessory):
+    """An accessory that is not available."""
+
+    @property
+    def available(self):
+        return False
+
+
 @pytest.fixture
 def driver():
-    with patch('pyhap.accessory_driver.HAPServer'), \
-        patch('pyhap.accessory_driver.Zeroconf'), \
-            patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+    with patch("pyhap.accessory_driver.HAPServer"), patch(
+        "pyhap.accessory_driver.Zeroconf"
+    ), patch("pyhap.accessory_driver.AccessoryDriver.persist"):
         yield AccessoryDriver()
 
 
 def test_auto_add_aid_mac(driver):
-    acc = Accessory(driver, 'Test Accessory')
+    acc = Accessory(driver, "Test Accessory")
     driver.add_accessory(acc)
     assert acc.aid == STANDALONE_AID
     assert driver.state.mac is not None
 
 
 def test_not_standalone_aid(driver):
-    acc = Accessory(driver, 'Test Accessory', aid=STANDALONE_AID + 1)
+    acc = Accessory(driver, "Test Accessory", aid=STANDALONE_AID + 1)
     with pytest.raises(ValueError):
         driver.add_accessory(acc)
 
 
 def test_persist_load():
-    with tempfile.NamedTemporaryFile(mode='r+') as file:
-        with patch('pyhap.accessory_driver.HAPServer'), \
-                patch('pyhap.accessory_driver.Zeroconf'):
+    with tempfile.NamedTemporaryFile(mode="r+") as file:
+        with patch("pyhap.accessory_driver.HAPServer"), patch(
+            "pyhap.accessory_driver.Zeroconf"
+        ):
             driver = AccessoryDriver(port=51234, persist_file=file.name)
             driver.persist()
             pk = driver.state.public_key
@@ -56,20 +69,21 @@ def test_persist_load():
 
 def test_external_zeroconf():
     zeroconf = MagicMock()
-    with patch('pyhap.accessory_driver.HAPServer'), \
-            patch('pyhap.accessory_driver.AccessoryDriver.persist'):
+    with patch("pyhap.accessory_driver.HAPServer"), patch(
+        "pyhap.accessory_driver.AccessoryDriver.persist"
+    ):
         driver = AccessoryDriver(port=51234, zeroconf_instance=zeroconf)
     assert driver.advertiser == zeroconf
 
 
 def test_service_callbacks(driver):
     bridge = Bridge(driver, "mybridge")
-    acc = Accessory(driver, 'TestAcc', aid=2)
-    acc2 = Accessory(driver, 'TestAcc2', aid=3)
+    acc = Accessory(driver, "TestAcc", aid=2)
+    acc2 = UnavailableAccessory(driver, "TestAcc2", aid=3)
 
-    service = Service(uuid1(), 'Lightbulb')
-    char_on = Characteristic('On', uuid1(), CHAR_PROPS)
-    char_brightness = Characteristic('Brightness', uuid1(), CHAR_PROPS)
+    service = Service(uuid1(), "Lightbulb")
+    char_on = Characteristic("On", uuid1(), CHAR_PROPS)
+    char_brightness = Characteristic("Brightness", uuid1(), CHAR_PROPS)
 
     service.add_characteristic(char_on)
     service.add_characteristic(char_brightness)
@@ -80,9 +94,9 @@ def test_service_callbacks(driver):
     acc.add_service(service)
     bridge.add_accessory(acc)
 
-    service2 = Service(uuid1(), 'Lightbulb')
-    char_on2 = Characteristic('On', uuid1(), CHAR_PROPS)
-    char_brightness2 = Characteristic('Brightness', uuid1(), CHAR_PROPS)
+    service2 = Service(uuid1(), "Lightbulb")
+    char_on2 = Characteristic("On", uuid1(), CHAR_PROPS)
+    char_brightness2 = Characteristic("Brightness", uuid1(), CHAR_PROPS)
 
     service2.add_characteristic(char_on2)
     service2.add_characteristic(char_brightness2)
@@ -100,28 +114,67 @@ def test_service_callbacks(driver):
 
     driver.add_accessory(bridge)
 
-    driver.set_characteristics({
-        HAP_REPR_CHARS: [{
-            HAP_REPR_AID: acc.aid,
-            HAP_REPR_IID: char_on_iid,
-            HAP_REPR_VALUE: True
-        }, {
-            HAP_REPR_AID: acc.aid,
-            HAP_REPR_IID: char_brightness_iid,
-            HAP_REPR_VALUE: 88
-        }, {
-            HAP_REPR_AID: acc2.aid,
-            HAP_REPR_IID: char_on2_iid,
-            HAP_REPR_VALUE: True
-        }, {
-            HAP_REPR_AID: acc2.aid,
-            HAP_REPR_IID: char_brightness2_iid,
-            HAP_REPR_VALUE: 12
-        }]
-    }, "mock_addr")
+    driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_on_iid,
+                    HAP_REPR_VALUE: True,
+                },
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_brightness_iid,
+                    HAP_REPR_VALUE: 88,
+                },
+                {
+                    HAP_REPR_AID: acc2.aid,
+                    HAP_REPR_IID: char_on2_iid,
+                    HAP_REPR_VALUE: True,
+                },
+                {
+                    HAP_REPR_AID: acc2.aid,
+                    HAP_REPR_IID: char_brightness2_iid,
+                    HAP_REPR_VALUE: 12,
+                },
+            ]
+        },
+        "mock_addr",
+    )
 
-    mock_callback2.assert_called_with({'On': True, 'Brightness': 12})
-    mock_callback.assert_called_with({'On': True, 'Brightness': 88})
+    mock_callback2.assert_called_with({"On": True, "Brightness": 12})
+    mock_callback.assert_called_with({"On": True, "Brightness": 88})
+
+    get_chars = driver.get_characteristics(
+        ["{}.{}".format(acc.aid, char_on_iid), "{}.{}".format(acc2.aid, char_on2_iid)]
+    )
+    assert get_chars == {
+        "characteristics": [
+            {"aid": acc.aid, "iid": char_on_iid, "status": 0, "value": True},
+            {"aid": acc2.aid, "iid": char_on2_iid, "status": -70402},
+        ]
+    }
+
+    def _fail_func():
+        raise ValueError
+
+    char_brightness.getter_callback = _fail_func
+    get_chars = driver.get_characteristics(
+        [
+            "{}.{}".format(acc.aid, char_on_iid),
+            "{}.{}".format(acc2.aid, char_on2_iid),
+            "{}.{}".format(acc2.aid, char_brightness_iid),
+            "{}.{}".format(acc.aid, char_brightness2_iid),
+        ]
+    )
+    assert get_chars == {
+        "characteristics": [
+            {"aid": acc.aid, "iid": char_on_iid, "status": 0, "value": True},
+            {"aid": acc2.aid, "iid": char_on2_iid, "status": -70402},
+            {"aid": acc2.aid, "iid": char_brightness2_iid, "status": -70402},
+            {"aid": acc.aid, "iid": char_brightness_iid, "status": -70402},
+        ]
+    }
 
 
 def test_start_stop_sync_acc(driver):
@@ -136,7 +189,7 @@ def test_start_stop_sync_acc(driver):
         def setup_message(self):
             pass
 
-    acc = Acc(driver, 'TestAcc')
+    acc = Acc(driver, "TestAcc")
     driver.add_accessory(acc)
     driver.start()
     assert not acc.running
@@ -144,7 +197,6 @@ def test_start_stop_sync_acc(driver):
 
 def test_start_stop_async_acc(driver):
     class Acc(Accessory):
-
         @Accessory.run_at_interval(0)
         async def run(self):
             driver.stop()
@@ -152,14 +204,14 @@ def test_start_stop_async_acc(driver):
         def setup_message(self):
             pass
 
-    acc = Acc(driver, 'TestAcc')
+    acc = Acc(driver, "TestAcc")
     driver.add_accessory(acc)
     driver.start()
     assert driver.loop.is_closed()
 
 
 def test_send_events(driver):
-    class LoopMock():
+    class LoopMock:
         runcount = 0
 
         def is_closed(self):
@@ -168,7 +220,7 @@ def test_send_events(driver):
                 return True
             return False
 
-    class HapServerMock():
+    class HapServerMock:
         pushed_events = []
 
         def push_event(self, bytedata, client_addr):
@@ -185,5 +237,7 @@ def test_send_events(driver):
     driver.send_events()
 
     # Only client2 and client3 get the event when client1 sent it
-    assert (driver.http_server.get_pushed_events() ==
-            [["bytedata", "client2"], ["bytedata", "client3"]])
+    assert driver.http_server.get_pushed_events() == [
+        ["bytedata", "client2"],
+        ["bytedata", "client3"],
+    ]


### PR DESCRIPTION
Implements #194 

Example usage
https://github.com/bdraco/home-assistant/commit/a37b1fb0c4839f496aeea665d7f575ec66f9587c

Adds an exception guard to prevent the encrypted connection from being dropped and causing homekit to stall usually caused by the `getter_callback` throwing an unexpected exception.