### PR TITLE
Ensure exception is still thrown in finish_request

### DIFF
--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -910,6 +910,7 @@ class HAPServer(socketserver.ThreadingMixIn,
             logger.debug('Connection timeout')
         except Exception as e:
             logger.debug('finish_request: %s', e, exc_info=True)
+            raise
         finally:
             logger.debug('Cleaning connection to %s', client_address)
             conn_sock = self.connections.pop(client_address, None)


### PR DESCRIPTION
The "Add logging of exceptions in finish_request" PR caused the exception to be suppressed instead of only adding logging.
