### PR TITLE
Split read/write encryption upgrade

### DIFF
--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -194,22 +194,29 @@ class HAPServerHandler(BaseHTTPRequestHandler):
             "pre_session_key": pre_session_key
         }
 
-    def _upgrade_to_encrypted(self):
+    def _upgrade_reader_to_encrypted(self):
         """Set encryption for the underlying transport.
 
-        @note: Replaces self.request, self.wfile and self.rfile.
+        Call BEFORE sending the final unencrypted
+        response.
+
+        @note: Replaces self.request and self.rfile.
         """
-        # Important: We must flush before switching to encrypted
-        # as there may still be data in the buffer which will be
-        # lost we switch to encrypted which will result in the
-        # HAP client/controller having to reconnect and try again.
-        self.wfile.flush()
         self.request = self.server.upgrade_to_encrypted(self.client_address,
                                                         self.enc_context["shared_key"])
         # Recreate the file handles over the socket
         # TODO: consider calling super().setup(), although semantically not correct
+        self.rfile = self.request.makefile('rb', self.rbufsize)  # pylint: disable=attribute-defined-outside-init
+
+    def _upgrade_writer_to_encrypted(self):
+        """Set encryption for the underlying transport. Step 2
+
+        Call AFTER sending the final unencrypted
+        response.
+
+        @note: Replaces self.connection and self.wfile
+        """
         self.connection = self.request  # pylint: disable=attribute-defined-outside-init
-        self.rfile = self.connection.makefile('rb', self.rbufsize)  # pylint: disable=attribute-defined-outside-init
         self.wfile = self.connection.makefile('wb')  # pylint: disable=attribute-defined-outside-init
         self.is_encrypted = True
 
@@ -243,6 +250,15 @@ class HAPServerHandler(BaseHTTPRequestHandler):
         #
         self.connection.sendall(b"".join(self._headers_buffer) + b"\r\n" + bytesdata)
         self._headers_buffer = []  # pylint: disable=attribute-defined-outside-init
+        # Important: We must flush before switching to encrypted
+        # as there may still be data in the buffer which will be
+        # lost we switch to encrypted which will result in the
+        # HAP client/controller having to reconnect and try again.
+        #
+        # Additionally if we do not flush after each response iOS
+        # seem to reschedule a request to subscribe over and over
+        # again.
+        self.wfile.flush()
 
     def dispatch(self):
         """Dispatch the request to the appropriate handler method."""
@@ -526,8 +542,9 @@ class HAPServerHandler(BaseHTTPRequestHandler):
         data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, b'\x04')
         self.send_response(200)
         self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
+        self._upgrade_reader_to_encrypted()
         self.end_response(data)
-        self._upgrade_to_encrypted()
+        self._upgrade_writer_to_encrypted()
         del self.enc_context
 
     def handle_accessories(self):

--- a/tests/test_hap_server.py
+++ b/tests/test_hap_server.py
@@ -85,11 +85,13 @@ def test_end_response_is_one_send():
         handler.connection = ConnectionMock()
         handler.requestline = "GET / HTTP/1.1"
         handler.send_response(200)
+        handler.wfile = MagicMock()
         handler.end_response(b"body")
         assert handler.connection.getsent() == [
             [b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbody"]
         ]
         assert handler._headers_buffer == []  # pylint: disable=protected-access
+        assert handler.wfile.called_once()
 
 
 def test_http_204_has_no_content_length():
@@ -117,6 +119,8 @@ def test_http_204_has_no_content_length():
         handler.connection = ConnectionMock()
         handler.requestline = "PUT / HTTP/1.1"
         handler.send_response(204)
+        handler.wfile = MagicMock()
         handler.end_response(b"")
         assert handler.connection.getsent() == [[b"HTTP/1.1 204 No Content\r\n\r\n"]]
         assert handler._headers_buffer == []  # pylint: disable=protected-access
+        assert handler.wfile.called_once()


### PR DESCRIPTION
#253 only fixed the write side of the issue.

Once the final response is sent data, can come
back over the wire before the reader is swapped
out to the encrypted reader.  This causes us to
loose the data and result in a disconnect.

Should solve #257