### PR TITLE
"-framerate" is required to control avfoundation

### DIFF
--- a/pyhap/camera.py
+++ b/pyhap/camera.py
@@ -213,7 +213,7 @@ NO_SRTP = b'\x01\x01\x02\x02\x00\x03\x00'
 
 FFMPEG_CMD = (
     # pylint: disable=bad-continuation
-    'ffmpeg -re -f avfoundation -i 0:0 -threads 0 '
+    'ffmpeg -re -f avfoundation -framerate {fps} -i 0:0 -threads 0 '
     '-vcodec libx264 -an -pix_fmt yuv420p -r {fps} -f rawvideo -tune zerolatency '
     '-vf scale={width}:{height} -b:v {v_max_bitrate}k -bufsize {v_max_bitrate}k '
     '-payload_type 99 -ssrc {v_ssrc} -f rtp '


### PR DESCRIPTION
Without this argument, avfoundation always generates the same frame rate, no matter what rate is negotiated by homekit (on my mac, this results in about 10fps)