### PR TITLE
✨ Support multiple accessories with same name

### DIFF
--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -38,11 +38,6 @@ class Accessory:
             standalone AID. Defaults to None, in which case the `AccessoryDriver`
             will assign the standalone AID to this `Accessory`.
         :type aid: int
-
-        :param setup_id: Setup ID can be provided, although, per spec, should be random
-            every time the instance is started. If not provided on init, will be random.
-            4 digit string 0-9 A-Z
-        :type setup_id: str
         """
         self.aid = aid
         self.display_name = display_name

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -56,6 +56,7 @@ CHAR_STAT_OK = 0
 SERVICE_COMMUNICATION_FAILURE = -70402
 SERVICE_CALLBACK = 0
 SERVICE_CALLBACK_DATA = 1
+HAP_SERVICE_TYPE = '_hap._tcp.local.'
 
 
 def callback(func):
@@ -86,9 +87,11 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
         self.state = state
 
         adv_data = self._get_advert_data()
+        # Append part of MAC address to prevent name conflicts
+        name_prefix = self.accessory.display_name + self.state.mac[-8:].replace(':', '')
         super().__init__(
-            '_hap._tcp.local.',
-            name=self.accessory.display_name + '._hap._tcp.local.',
+            HAP_SERVICE_TYPE,
+            name=name_prefix + '.' + HAP_SERVICE_TYPE,
             port=self.state.port,
             weight=0,
             priority=0,

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -88,10 +88,14 @@ class AccessoryMDNSServiceInfo(ServiceInfo):
 
         adv_data = self._get_advert_data()
         # Append part of MAC address to prevent name conflicts
-        name_prefix = self.accessory.display_name + self.state.mac[-8:].replace(':', '')
+        name = '{} {}.{}'.format(
+            self.accessory.display_name,
+            self.state.mac[-8:].replace(':', ''),
+            HAP_SERVICE_TYPE
+        )
         super().__init__(
             HAP_SERVICE_TYPE,
-            name=name_prefix + '.' + HAP_SERVICE_TYPE,
+            name=name,
             port=self.state.port,
             weight=0,
             priority=0,


### PR DESCRIPTION
I was running into an issue trying to deploy the same code for an accessory on two different RPis implemented with this library, with different hostnames. As soon as the second one was on, neither accessory would work anymore, they were both getting some corrupted/bad requests. They both had the same display_name, so I changed one and suddenly everything was working correctly. But this was weird, as I thought the autodiscovery features should account for this. That led me to this SO answer: https://stackoverflow.com/a/53867271/375530

Comparing what other HomeKit accessories do, it seems they append some parts of their MAC address to the mDNS name, giving some uniqueness if there are multiple bridges on the same network, for instance. Since the accessory I wrote has multiple physical copies, appending the MAC address would solve the issue. I have tested this by running this code on my Pi and seeing the new name get picked up correctly without clashing.