### PR TITLE
Improve loop handling

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -319,9 +319,9 @@ class AccessoryDriver:
     async def async_stop(self):
         """Stops the AccessoryDriver and shutdown all remaining tasks."""
         await self.async_add_job(self._do_stop)
-        logger.debug('Shutdown executors')
         # Executor=None means a loop wasn't passed in
         if self.executor is not None:
+            logger.debug('Shutdown executors')
             self.executor.shutdown()
             self.loop.stop()
         logger.debug('Stop completed')

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -236,7 +236,7 @@ class AccessoryDriver:
         self.http_server = HAPServer(network_tuple, self)
 
     def start(self):
-        """Start the event loop and call `_do_start`.
+        """Start the event loop and call `start_service`.
 
         Pyhap will be stopped gracefully on a KeyBoardInterrupt.
         """
@@ -250,7 +250,7 @@ class AccessoryDriver:
             else:
                 logger.debug('Not setting a child watcher. Set one if '
                              'subprocesses will be started outside the main thread.')
-            self.add_job(self._do_start)
+            self.add_job(self.start_service)
             self.loop.run_forever()
         except KeyboardInterrupt:
             logger.debug('Got a KeyboardInterrupt, stopping driver')
@@ -261,7 +261,7 @@ class AccessoryDriver:
             self.loop.close()
             logger.info('Closed the event loop')
 
-    def _do_start(self):
+    def start_service(self):
         """Starts the accessory.
 
         - Call the accessory's run method.

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -215,7 +215,7 @@ class AccessoryDriver:
         self.topics = {}  # topic: set of (address, port) of subscribed clients
         self.topic_lock = threading.Lock()  # for exclusive access to the topics
         self.loader = loader or Loader()
-        self.aio_stop_event = asyncio.Event()
+        self.aio_stop_event = asyncio.Event(loop=loop)
         self.stop_event = threading.Event()
         self.event_queue = queue.Queue()  # (topic, bytes)
         self.send_event_thread = None  # the event dispatch thread


### PR DESCRIPTION
This improves loop handling for HAP-Python:
 - Do not change the default executor of passed in loops
 - Do not shut down loops/executor pools that were passed in