### PR TITLE
Fix thread safety in get_characteristics

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -670,6 +670,8 @@ class AccessoryDriver:
                     available = True
                 else:
                     acc = self.accessory.accessories.get(aid)
+                    if acc is None:
+                        continue
                     available = acc.available
                     char = acc.iid_manager.get_obj(iid)
 


### PR DESCRIPTION
Fixes

```
AttributeError: 'NoneType' object has no attribute 'available'
2020-10-29 11:20:44 ERROR (Thread-27) [pyhap.accessory_driver] Unexpected error getting value for characteristic <built-in function id>.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pyhap/accessory_driver.py", line 673, in get_characteristics
    available = acc.available
```

Reported here: https://github.com/home-assistant/core/issues/42157#issuecomment-719064388