### PR TITLE
Handle request for an empty read instead of throwing an exception

### DIFF
--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -765,7 +765,13 @@ class HAPSocket:
         The received full cipher blocks are decrypted and returned and partial cipher
         blocks are buffered locally.
         """
-        assert not flags and buflen
+        assert not flags
+
+        if buflen == 0:
+            # If the reads get aligned just right, it possible that we
+            # could be asked to read zero bytes. Since we do not want to block
+            # we return an empty bytes string.
+            return b""
 
         result = self.curr_decrypted
 


### PR DESCRIPTION
Looks like https://github.com/ikalchev/HAP-python/issues/230 is still happening:

```
Traceback (most recent call last):
  File "/home/homeassistant/.pyenv/versions/3.8.3/lib/python3.8/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/pyhap/hap_server.py", line 943, in finish_request
    self.RequestHandlerClass(request, client_address,
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/pyhap/hap_server.py", line 164, in __init__
    super(HAPServerHandler, self).__init__(sock, client_addr, server)
  File "/home/homeassistant/.pyenv/versions/3.8.3/lib/python3.8/socketserver.py", line 720, in __init__
    self.handle()
  File "/home/homeassistant/.pyenv/versions/3.8.3/lib/python3.8/http/server.py", line 429, in handle
    self.handle_one_request()
  File "/home/homeassistant/.pyenv/versions/3.8.3/lib/python3.8/http/server.py", line 395, in handle_one_request
    self.raw_requestline = self.rfile.readline(65537)
  File "/home/homeassistant/.pyenv/versions/3.8.3/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/pyhap/hap_server.py", line 758, in recv_into
    data = self.recv(nbytes or len(buffer), flags)
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/pyhap/hap_server.py", line 779, in recv
    block_length_bytes = self.socket.recv(
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/pyhap/hap_server.py", line 768, in recv
    assert not flags and buflen
AssertionError
----------------------------------------
```