### PR TITLE
Timeout client sockets after 300 seconds 

### DIFF
--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -279,6 +279,9 @@ class HAPServerHandler(BaseHTTPRequestHandler):
             self.send_response_with_status(401, HAP_SERVER_STATUS.INSUFFICIENT_PRIVILEGES)
         except TimeoutException:
             self.send_response_with_status(500, HAP_SERVER_STATUS.OPERATION_TIMED_OUT)
+        except socket.timeout:
+            self.send_response_with_status(500, HAP_SERVER_STATUS.OPERATION_TIMED_OUT)
+            self.close_connection = True
         except Exception:  # pylint: disable=broad-except
             logger.exception("Failed to process request for: %s", path)
             self.send_response_with_status(500, HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE)

--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -888,6 +888,8 @@ class HAPServer(socketserver.ThreadingMixIn,
     TIMEOUT_ERRNO_CODES = (errno.ECONNRESET, errno.EPIPE, errno.EHOSTUNREACH,
                            errno.ETIMEDOUT, errno.EHOSTDOWN, errno.EBADF)
 
+    CLIENT_SOCKET_TIMEOUT = 300
+
     @classmethod
     def create_hap_event(cls, bytesdata):
         """Creates a HAP HTTP EVENT response for the given data.
@@ -939,6 +941,7 @@ class HAPServer(socketserver.ThreadingMixIn,
         """Calls the super's method, caches the connection and returns."""
         client_socket, client_addr = super(HAPServer, self).get_request()
         logger.info("Got connection with %s.", client_addr)
+        client_socket.settimeout(self.CLIENT_SOCKET_TIMEOUT)
         self.connections[client_addr] = client_socket
         return (client_socket, client_addr)
 


### PR DESCRIPTION
This is an adjusted version of #222 that ensures that the client knows the connection is closed by sending a 500 response when it the socket times out.  When testing #222 I was seeing `No Response` on devices when the socket timed out because the client thought it was still connected.