### PR TITLE
Properly handle snapshots if camera added to bridge

### DIFF
--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -652,7 +652,6 @@ class HAPServerHandler:
 
     def handle_resource(self):
         """Get a snapshot from the camera."""
-
         data = json.loads(self.request_body.decode("utf-8"))
 
         if self.accessory_handler.accessory.category == CATEGORY_BRIDGE:


### PR DESCRIPTION
[Updated pull request to work correctly with 3.2.0]

The handle_resource method from HAPServer class does not support situation when camera added to bridge and fails with Got a request for snapshot, but the Accessory does not define a "get_snapshot" method error. This is because it tries to check if bridge itself has the get_snapshot method.

This pull request fixes this problem.