### PR TITLE
Implement list pairings

### DIFF
--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -249,6 +249,16 @@ class HAPServerHandler:
         self.response = None
         return response
 
+    def generic_failure_response(self):
+        """Generate a generic failure response."""
+        self.response = HAPResponse()
+        self.send_response_with_status(
+            500, HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE
+        )
+        response = self.response
+        self.response = None
+        return response
+
     def send_response_with_status(self, http_code, hap_server_status):
         """Send a generic HAP status response."""
         self.send_response(http_code)

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -9,6 +9,7 @@ import logging
 from urllib.parse import parse_qs, urlparse
 import uuid
 
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 import curve25519
 import ed25519
@@ -31,9 +32,31 @@ class HAPResponse:
         self.status_code = 500
         self.reason = "Internal Server Error"
         self.headers = []
-        self.body = []
+        self.body = b""
         self.shared_key = None
         self.task = None
+        self.pairing_changed = False
+
+    def __repr__(self):
+        """Return a human readable view of the response."""
+        return "<HAPResponse {} {} {} {}>".format(
+            self.status_code, self.reason, self.headers, self.body
+        )
+
+
+class HAP_TLV_STATES:
+    M1 = b"\x01"
+    M2 = b"\x02"
+    M3 = b"\x03"
+    M4 = b"\x04"
+    M5 = b"\x05"
+    M6 = b"\x06"
+
+
+class HAP_TLV_ERRORS:
+    AUTHENTICATION = b"\x02"
+    UNAVAILABLE = b"\x06"
+    BUSY = b"\x07"
 
 
 # Various "tag" constants for HAP's TLV encoding.
@@ -47,6 +70,7 @@ class HAP_TLV_TAGS:
     SEQUENCE_NUM = b"\x06"
     ERROR_CODE = b"\x07"
     PROOF = b"\x0A"
+    PERMISSIONS = b"\x0B"
 
 
 # Status codes for underlying HAP calls
@@ -65,10 +89,9 @@ class HAP_SERVER_STATUS:
     INSUFFICIENT_AUTHORIZATION = -70411
 
 
-# Error codes and the like, guessed by packet inspection
-class HAP_OPERATION_CODE:
-    INVALID_REQUEST = b"\x02"
-    INVALID_SIGNATURE = b"\x04"
+class HAP_PERMISSIONS:
+    USER = b"\x00"
+    ADMIN = b"\x01"
 
 
 class TimeoutException(Exception):
@@ -194,9 +217,9 @@ class HAPServerHandler:
         self.response = response
 
         logger.debug(
-            "Request %s from address '%s' for path '%s': %s",
-            self.command,
+            "%s: Request %s for path '%s': %s",
             self.client_address,
+            self.command,
             self.path,
             self.headers,
         )
@@ -216,7 +239,9 @@ class HAPServerHandler:
         except TimeoutException:
             self.send_response_with_status(500, HAP_SERVER_STATUS.OPERATION_TIMED_OUT)
         except Exception:  # pylint: disable=broad-except
-            logger.exception("Failed to process request for: %s", path)
+            logger.exception(
+                "%s: Failed to process request for: %s", self.client_address, path
+            )
             self.send_response_with_status(
                 500, HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE
             )
@@ -238,11 +263,11 @@ class HAPServerHandler:
         tlv_objects = tlv.decode(self.request_body)
         sequence = tlv_objects[HAP_TLV_TAGS.SEQUENCE_NUM]
 
-        if sequence == b"\x01":
+        if sequence == HAP_TLV_STATES.M1:
             self._pairing_one()
-        elif sequence == b"\x03":
+        elif sequence == HAP_TLV_STATES.M3:
             self._pairing_two(tlv_objects)
-        elif sequence == b"\x05":
+        elif sequence == HAP_TLV_STATES.M5:
             self._pairing_three(tlv_objects)
 
     def _pairing_one(self):
@@ -250,22 +275,19 @@ class HAPServerHandler:
 
         The SRP verifier is created at this step.
         """
-        logger.debug("Pairing [1/5]")
+        logger.debug("%s: Pairing [1/5]", self.client_address)
         self.accessory_handler.setup_srp_verifier()
         salt, B = self.accessory_handler.srp_verifier.get_challenge()
 
         data = tlv.encode(
             HAP_TLV_TAGS.SEQUENCE_NUM,
-            b"\x02",
+            HAP_TLV_STATES.M2,
             HAP_TLV_TAGS.SALT,
             salt,
             HAP_TLV_TAGS.PUBLIC_KEY,
             long_to_bytes(B),
         )
-
-        self.send_response(200)
-        self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-        self.end_response(data)
+        self._send_tlv_pairing_response(data)
 
     def _pairing_two(self, tlv_objects):
         """Obtain the challenge from the client (A) and client's proof that it
@@ -275,7 +297,7 @@ class HAPServerHandler:
         @param tlv_objects: The TLV data received from the client.
         @type tlv_object: dict
         """
-        logger.debug("Pairing [2/5]")
+        logger.debug("%s: Pairing [2/5]", self.client_address)
         A = tlv_objects[HAP_TLV_TAGS.PUBLIC_KEY]
         M = tlv_objects[HAP_TLV_TAGS.PASSWORD_PROOF]
         verifier = self.accessory_handler.srp_verifier
@@ -284,23 +306,16 @@ class HAPServerHandler:
         hamk = verifier.verify(M)
 
         if hamk is None:  # Probably the provided pincode was wrong.
-            response = tlv.encode(
-                HAP_TLV_TAGS.SEQUENCE_NUM,
-                b"\x04",
-                HAP_TLV_TAGS.ERROR_CODE,
-                HAP_OPERATION_CODE.INVALID_REQUEST,
-            )
-            self.send_response(200)
-            self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-            self.end_response(response)
+            self._send_authentication_error_tlv_response(HAP_TLV_STATES.M4)
             return
 
         data = tlv.encode(
-            HAP_TLV_TAGS.SEQUENCE_NUM, b"\x04", HAP_TLV_TAGS.PASSWORD_PROOF, hamk
+            HAP_TLV_TAGS.SEQUENCE_NUM,
+            HAP_TLV_STATES.M4,
+            HAP_TLV_TAGS.PASSWORD_PROOF,
+            hamk,
         )
-        self.send_response(200)
-        self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-        self.end_response(data)
+        self._send_tlv_pairing_response(data)
 
     def _pairing_three(self, tlv_objects):
         """Expand the SRP session key to obtain a new key. Use it to verify and decrypt
@@ -309,7 +324,7 @@ class HAPServerHandler:
         @param tlv_objects: The TLV data received from the client.
         @type tlv_object: dict
         """
-        logger.debug("Pairing [3/5]")
+        logger.debug("%s: Pairing [3/5]", self.client_address)
         encrypted_data = tlv_objects[HAP_TLV_TAGS.ENCRYPTED_DATA]
 
         session_key = self.accessory_handler.srp_verifier.get_session_key()
@@ -347,7 +362,7 @@ class HAPServerHandler:
         @param encryption_key: The encryption key for this step.
         @type encryption_key: bytes
         """
-        logger.debug("Pairing [4/5]")
+        logger.debug("%s: Pairing [4/5]", self.client_address)
         session_key = self.accessory_handler.srp_verifier.get_session_key()
         output_key = hap_hkdf(
             long_to_bytes(session_key), self.PAIRING_4_SALT, self.PAIRING_4_INFO
@@ -370,7 +385,7 @@ class HAPServerHandler:
 
         Parameters are as for _pairing_four.
         """
-        logger.debug("Pairing [5/5]")
+        logger.debug("%s: Pairing [5/5]", self.client_address)
         session_key = self.accessory_handler.srp_verifier.get_session_key()
         output_key = hap_hkdf(
             long_to_bytes(session_key), self.PAIRING_5_SALT, self.PAIRING_5_INFO
@@ -406,13 +421,12 @@ class HAPServerHandler:
 
         tlv_data = tlv.encode(
             HAP_TLV_TAGS.SEQUENCE_NUM,
-            b"\x06",
+            HAP_TLV_STATES.M6,
             HAP_TLV_TAGS.ENCRYPTED_DATA,
             aead_message,
         )
-        self.send_response(200)
-        self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-        self.end_response(tlv_data)
+        self.response.pairing_changed = True
+        self._send_tlv_pairing_response(tlv_data)
 
     def handle_pair_verify(self):
         """Handles arbitrary step of the pair verify process.
@@ -424,9 +438,9 @@ class HAPServerHandler:
 
         tlv_objects = tlv.decode(self.request_body)
         sequence = tlv_objects[HAP_TLV_TAGS.SEQUENCE_NUM]
-        if sequence == b"\x01":
+        if sequence == HAP_TLV_STATES.M1:
             self._pair_verify_one(tlv_objects)
-        elif sequence == b"\x03":
+        elif sequence == HAP_TLV_STATES.M3:
             self._pair_verify_two(tlv_objects)
         else:
             raise ValueError(
@@ -439,7 +453,7 @@ class HAPServerHandler:
         @param tlv_objects: The TLV data received from the client.
         @type tlv_object: dict
         """
-        logger.debug("Pair verify [1/2].")
+        logger.debug("%s: Pair verify [1/2].", self.client_address)
         client_public = tlv_objects[HAP_TLV_TAGS.PUBLIC_KEY]
 
         private_key = curve25519.Private()
@@ -468,15 +482,13 @@ class HAPServerHandler:
         aead_message = bytes(cipher.encrypt(self.PVERIFY_1_NONCE, bytes(message), b""))
         data = tlv.encode(
             HAP_TLV_TAGS.SEQUENCE_NUM,
-            b"\x02",
+            HAP_TLV_STATES.M2,
             HAP_TLV_TAGS.ENCRYPTED_DATA,
             aead_message,
             HAP_TLV_TAGS.PUBLIC_KEY,
             public_key.serialize(),
         )
-        self.send_response(200)
-        self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-        self.end_response(data)
+        self._send_tlv_pairing_response(data)
 
     def _pair_verify_two(self, tlv_objects):
         """Verify the client proof and upgrade to encrypted transport.
@@ -484,12 +496,17 @@ class HAPServerHandler:
         @param tlv_objects: The TLV data received from the client.
         @type tlv_object: dict
         """
-        logger.debug("Pair verify [2/2]")
+        logger.debug("%s: Pair verify [2/2]", self.client_address)
         encrypted_data = tlv_objects[HAP_TLV_TAGS.ENCRYPTED_DATA]
         cipher = ChaCha20Poly1305(self.enc_context["pre_session_key"])
-        decrypted_data = cipher.decrypt(
-            self.PVERIFY_2_NONCE, bytes(encrypted_data), b""
-        )
+        try:
+            decrypted_data = cipher.decrypt(
+                self.PVERIFY_2_NONCE, bytes(encrypted_data), b""
+            )
+        except InvalidTag:
+            self._send_authentication_error_tlv_response(HAP_TLV_STATES.M4)
+            return
+
         assert decrypted_data is not None  # TODO:
 
         dec_tlv_objects = tlv.decode(bytes(decrypted_data))
@@ -500,45 +517,34 @@ class HAPServerHandler:
             + self.enc_context["public_key"].serialize()
         )
 
-        client_uuid = uuid.UUID(str(client_username, "ascii"))
+        client_uuid = uuid.UUID(str(client_username, "utf-8"))
         perm_client_public = self.state.paired_clients.get(client_uuid)
         if perm_client_public is None:
-            logger.debug(
-                "Client %s attempted pair verify without being paired first.",
+            logger.error(
+                "%s: Client %s attempted pair verify without being paired to %s first.",
+                self.client_address,
                 client_uuid,
+                self.accessory_handler.accessory.display_name,
             )
-            self.send_response(200)
-            self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-            data = tlv.encode(
-                HAP_TLV_TAGS.ERROR_CODE, HAP_OPERATION_CODE.INVALID_REQUEST
-            )
-            self.end_response(data)
+            self._send_authentication_error_tlv_response(HAP_TLV_STATES.M4)
             return
 
         verifying_key = ed25519.VerifyingKey(perm_client_public)
         try:
             verifying_key.verify(dec_tlv_objects[HAP_TLV_TAGS.PROOF], material)
         except ed25519.BadSignatureError:
-            logger.error("Bad signature, abort.")
-            self.send_response(200)
-            self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-            data = tlv.encode(
-                HAP_TLV_TAGS.ERROR_CODE, HAP_OPERATION_CODE.INVALID_REQUEST
-            )
-            self.end_response(data)
+            logger.error("%s: Bad signature, abort.", self.client_address)
+            self._send_authentication_error_tlv_response(HAP_TLV_STATES.M4)
             return
 
         logger.debug(
-            "Pair verify with client '%s' completed. Switching to "
+            "%s: Pair verify with client completed. Switching to "
             "encrypted transport.",
             self.client_address,
         )
 
-        data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, b"\x04")
-        self.send_response(200)
-        self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-        self.end_response(data)
-
+        data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, HAP_TLV_STATES.M4)
+        self._send_tlv_pairing_response(data)
         self.response.shared_key = self.enc_context["shared_key"]
         self.is_encrypted = True
         del self.enc_context
@@ -572,13 +578,15 @@ class HAPServerHandler:
         """Handles a client request to update certain characteristics."""
         if not self.is_encrypted:
             logger.warning(
-                "Attempt to access unauthorised content from %s", self.client_address
+                "%s: Attempt to access unauthorised content", self.client_address
             )
             self.send_response(HTTPStatus.UNAUTHORIZED)
-            self.end_response(b"")
+            return
 
         requested_chars = json.loads(self.request_body.decode("utf-8"))
-        logger.debug("Set characteristics content: %s", requested_chars)
+        logger.debug(
+            "%s: Set characteristics content: %s", self.client_address, requested_chars
+        )
 
         # TODO: Outline how chars return errors on set_chars.
         try:
@@ -586,17 +594,18 @@ class HAPServerHandler:
                 requested_chars, self.client_address
             )
         except Exception as ex:  # pylint: disable=broad-except
-            logger.exception("Exception in set_characteristics: %s", ex)
+            logger.exception(
+                "%s: Exception in set_characteristics: %s", self.client_address, ex
+            )
             self.send_response(HTTPStatus.BAD_REQUEST)
-            self.end_response(b"")
         else:
             self.send_response(HTTPStatus.NO_CONTENT)
-            self.end_response(b"")
 
     def handle_pairings(self):
         """Handles a client request to update or remove a pairing."""
         if not self.is_encrypted:
-            raise UnprivilegedRequestException
+            self._send_authentication_error_tlv_response(HAP_TLV_STATES.M2)
+            return
 
         tlv_objects = tlv.decode(self.request_body)
         request_type = tlv_objects[HAP_TLV_TAGS.REQUEST_TYPE][0]
@@ -604,6 +613,8 @@ class HAPServerHandler:
             self._handle_add_pairing(tlv_objects)
         elif request_type == 4:
             self._handle_remove_pairing(tlv_objects)
+        elif request_type == 5:
+            self._handle_list_pairings()
         else:
             raise ValueError(
                 "Unknown pairing request type of %s during pair verify" % (request_type)
@@ -611,44 +622,74 @@ class HAPServerHandler:
 
     def _handle_add_pairing(self, tlv_objects):
         """Update client information."""
-        logger.debug("Adding client pairing.")
+        logger.debug("%s: Adding client pairing.", self.client_address)
         client_username = tlv_objects[HAP_TLV_TAGS.USERNAME]
         client_public = tlv_objects[HAP_TLV_TAGS.PUBLIC_KEY]
         client_uuid = uuid.UUID(str(client_username, "utf-8"))
         should_confirm = self.accessory_handler.pair(client_uuid, client_public)
         if not should_confirm:
-            self.send_response_with_status(
-                500, HAP_SERVER_STATUS.INVALID_VALUE_IN_REQUEST
-            )
+            self._send_authentication_error_tlv_response(HAP_TLV_STATES.M2)
             return
 
-        data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, b"\x02")
-        self.send_response(200)
-        self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
-        self.end_response(data)
-
-        # Avoid updating the announcement until
-        # after the response is sent as homekit will
-        # drop the connection and fail to pair if it
-        # sees the accessory is now paired as it doesn't
-        # know that it was the one doing the pairing.
-        self.accessory_handler.finish_pair()
+        data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, HAP_TLV_STATES.M2)
+        self._send_tlv_pairing_response(data)
 
     def _handle_remove_pairing(self, tlv_objects):
         """Remove pairing with the client."""
-        logger.debug("Removing client pairing.")
+        logger.debug("%s: Removing client pairing.", self.client_address)
         client_username = tlv_objects[HAP_TLV_TAGS.USERNAME]
         client_uuid = uuid.UUID(str(client_username, "utf-8"))
-        self.accessory_handler.unpair(client_uuid)
+        was_paired = self.state.paired
+        # If the client does not exist, we must
+        # respond with success per the spec
+        if client_uuid in self.state.paired_clients:
+            self.accessory_handler.unpair(client_uuid)
 
-        data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, b"\x02")
+        data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, HAP_TLV_STATES.M2)
+        self._send_tlv_pairing_response(data)
+
+        if not self.state.paired_clients and was_paired:
+            # Only update the announcement when the last
+            # client is removed, otherwise the controller
+            # may not remove them all
+            logger.debug("%s: updating mdns to unpaired", self.client_address)
+            self.response.pairing_changed = True
+
+    def _handle_list_pairings(self):
+        """List current pairings."""
+        logger.debug("%s: list pairings", self.client_address)
+        response = [HAP_TLV_TAGS.SEQUENCE_NUM, HAP_TLV_STATES.M2]
+        for client_uuid, client_public in self.state.paired_clients.items():
+            response.extend(
+                [
+                    HAP_TLV_TAGS.USERNAME,
+                    str(client_uuid).encode("utf-8"),
+                    HAP_TLV_TAGS.PUBLIC_KEY,
+                    client_public,
+                    HAP_TLV_TAGS.PERMISSIONS,
+                    HAP_PERMISSIONS.ADMIN,
+                ]
+            )
+
+        data = tlv.encode(*response)
+        self._send_tlv_pairing_response(data)
+
+    def _send_authentication_error_tlv_response(self, sequence):
+        """Send an authentication error tlv response."""
+        self._send_tlv_pairing_response(
+            tlv.encode(
+                HAP_TLV_TAGS.SEQUENCE_NUM,
+                sequence,
+                HAP_TLV_TAGS.ERROR_CODE,
+                HAP_TLV_ERRORS.AUTHENTICATION,
+            )
+        )
+
+    def _send_tlv_pairing_response(self, data):
+        """Send a TLV encoded pairing response."""
         self.send_response(200)
         self.send_header("Content-Type", self.PAIRING_RESPONSE_TYPE)
         self.end_response(data)
-
-        # Avoid updating the announcement until
-        # after the response is sent.
-        self.accessory_handler.finish_pair()
 
     def handle_resource(self):
         """Get a snapshot from the camera."""

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -166,7 +166,10 @@ class HAPServerProtocol(asyncio.Protocol):
         """Handle delayed response."""
         response = self.response
         self.response = None
-        response.body = task.result()
+        try:
+            response.body = task.result()
+        except Exception:  # pylint: disable=broad-except
+            response = self.handler.generic_failure_response()
         self.send_response(response)
 
     def _handle_invalid_conn_state(self, message):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,8 @@ import os
 # Absolutize paths to coverage config and output file because tests that
 # spawn subprocesses also changes current working directory.
 _sourceroot = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if 'COV_CORE_CONFIG' in os.environ:
-    os.environ['COVERAGE_FILE'] = os.path.join(_sourceroot, '.coverage')
-    os.environ['COV_CORE_CONFIG'] = os.path.join(_sourceroot,
-                                                 os.environ['COV_CORE_CONFIG'])
+if "COV_CORE_CONFIG" in os.environ:
+    os.environ["COVERAGE_FILE"] = os.path.join(_sourceroot, ".coverage")
+    os.environ["COV_CORE_CONFIG"] = os.path.join(
+        _sourceroot, os.environ["COV_CORE_CONFIG"]
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 """Test fictures and mocks."""
 
+import asyncio
 from unittest.mock import patch
 
-import asyncio
 import pytest
 
-from pyhap.loader import Loader
 from pyhap.accessory_driver import AccessoryDriver
+from pyhap.loader import Loader
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def mock_driver():
     yield MockDriver()
 
@@ -22,8 +22,7 @@ def driver():
         yield AccessoryDriver()
 
 
-class MockDriver():
-
+class MockDriver:
     def __init__(self):
         self.loader = Loader()
 

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -3,10 +3,10 @@ import pytest
 
 from pyhap.accessory import Accessory, Bridge
 from pyhap.const import (
-    STANDALONE_AID,
     CATEGORY_CAMERA,
-    CATEGORY_TELEVISION,
     CATEGORY_TARGET_CONTROLLER,
+    CATEGORY_TELEVISION,
+    STANDALONE_AID,
 )
 from pyhap.state import State
 
@@ -46,6 +46,7 @@ def test_acc_set_primary_service(mock_driver):
     acc = Accessory(mock_driver, "Test Accessory")
     service = acc.driver.loader.get_service("Television")
     acc.add_service(service)
+    assert "Television" in str(acc)
     linked_service = acc.driver.loader.get_service("TelevisionSpeaker")
     acc.add_service(linked_service)
     assert acc.get_service("Television").is_primary_service is None
@@ -61,12 +62,14 @@ def test_acc_set_primary_service(mock_driver):
 
 
 def test_bridge_init(mock_driver):
-    Bridge(mock_driver, "Test Bridge")
+    bridge = Bridge(mock_driver, "Test Bridge")
+    assert bridge.available is True
 
 
 def test_bridge_add_accessory(mock_driver):
     bridge = Bridge(mock_driver, "Test Bridge")
     acc = Accessory(mock_driver, "Test Accessory", aid=2)
+    assert acc.available is True
     bridge.add_accessory(acc)
     acc2 = Accessory(mock_driver, "Test Accessory 2")
     bridge.add_accessory(acc2)
@@ -111,3 +114,197 @@ def test_xhm_uri(mock_driver):
     )
     mock_driver.state.setup_id = "BBBB"
     assert acc_1.xhm_uri() == "X-HM://00VPU8UEKBBBB"
+
+
+def test_set_info_service(mock_driver):
+    acc_1 = Accessory(mock_driver, "Test Accessory 1", aid=2)
+    acc_1.set_info_service("firmware", "manufacturer", "model", "serial")
+    serv_info = acc_1.get_service("AccessoryInformation")
+    assert serv_info.get_characteristic("FirmwareRevision").value == "firmware"
+    assert serv_info.get_characteristic("Manufacturer").value == "manufacturer"
+    assert serv_info.get_characteristic("Model").value == "model"
+    assert serv_info.get_characteristic("SerialNumber").value == "serial"
+
+
+def test_to_hap(mock_driver):
+    bridge = Bridge(mock_driver, "Test Bridge")
+    acc = Accessory(mock_driver, "Test Accessory", aid=2)
+    assert acc.available is True
+    bridge.add_accessory(acc)
+
+    assert bridge.to_HAP() == [
+        {
+            "aid": 1,
+            "services": [
+                {
+                    "iid": 1,
+                    "type": "0000003E-0000-1000-8000-0026BB765291",
+                    "characteristics": [
+                        {
+                            "iid": 2,
+                            "type": "00000014-0000-1000-8000-0026BB765291",
+                            "description": "Identify",
+                            "perms": ["pw"],
+                            "format": "bool",
+                        },
+                        {
+                            "iid": 3,
+                            "type": "00000020-0000-1000-8000-0026BB765291",
+                            "description": "Manufacturer",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "",
+                        },
+                        {
+                            "iid": 4,
+                            "type": "00000021-0000-1000-8000-0026BB765291",
+                            "description": "Model",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "",
+                        },
+                        {
+                            "iid": 5,
+                            "type": "00000023-0000-1000-8000-0026BB765291",
+                            "description": "Name",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "Test Bridge",
+                        },
+                        {
+                            "iid": 6,
+                            "type": "00000030-0000-1000-8000-0026BB765291",
+                            "description": "SerialNumber",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "default",
+                        },
+                        {
+                            "iid": 7,
+                            "type": "00000052-0000-1000-8000-0026BB765291",
+                            "description": "FirmwareRevision",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "",
+                        },
+                    ],
+                }
+            ],
+        },
+        {
+            "aid": 2,
+            "services": [
+                {
+                    "iid": 1,
+                    "type": "0000003E-0000-1000-8000-0026BB765291",
+                    "characteristics": [
+                        {
+                            "iid": 2,
+                            "type": "00000014-0000-1000-8000-0026BB765291",
+                            "description": "Identify",
+                            "perms": ["pw"],
+                            "format": "bool",
+                        },
+                        {
+                            "iid": 3,
+                            "type": "00000020-0000-1000-8000-0026BB765291",
+                            "description": "Manufacturer",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "",
+                        },
+                        {
+                            "iid": 4,
+                            "type": "00000021-0000-1000-8000-0026BB765291",
+                            "description": "Model",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "",
+                        },
+                        {
+                            "iid": 5,
+                            "type": "00000023-0000-1000-8000-0026BB765291",
+                            "description": "Name",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "Test Accessory",
+                        },
+                        {
+                            "iid": 6,
+                            "type": "00000030-0000-1000-8000-0026BB765291",
+                            "description": "SerialNumber",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "default",
+                        },
+                        {
+                            "iid": 7,
+                            "type": "00000052-0000-1000-8000-0026BB765291",
+                            "description": "FirmwareRevision",
+                            "perms": ["pr"],
+                            "format": "string",
+                            "value": "",
+                        },
+                    ],
+                }
+            ],
+        },
+    ]
+    assert acc.to_HAP() == {
+        "aid": 2,
+        "services": [
+            {
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "iid": 2,
+                        "type": "00000014-0000-1000-8000-0026BB765291",
+                        "description": "Identify",
+                        "perms": ["pw"],
+                        "format": "bool",
+                    },
+                    {
+                        "iid": 3,
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "description": "Manufacturer",
+                        "perms": ["pr"],
+                        "format": "string",
+                        "value": "",
+                    },
+                    {
+                        "iid": 4,
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "description": "Model",
+                        "perms": ["pr"],
+                        "format": "string",
+                        "value": "",
+                    },
+                    {
+                        "iid": 5,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "description": "Name",
+                        "perms": ["pr"],
+                        "format": "string",
+                        "value": "Test Accessory",
+                    },
+                    {
+                        "iid": 6,
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "description": "SerialNumber",
+                        "perms": ["pr"],
+                        "format": "string",
+                        "value": "default",
+                    },
+                    {
+                        "iid": 7,
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "description": "FirmwareRevision",
+                        "perms": ["pr"],
+                        "format": "string",
+                        "value": "",
+                    },
+                ],
+            }
+        ],
+    }

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -60,6 +60,17 @@ def test_persist_load():
     assert driver.state.public_key == pk
 
 
+def test_persist_cannot_write():
+    with tempfile.NamedTemporaryFile(mode="r+") as file:
+        with patch("pyhap.accessory_driver.HAPServer"), patch(
+            "pyhap.accessory_driver.Zeroconf"
+        ):
+            driver = AccessoryDriver(port=51234, persist_file=file.name)
+            driver.persist_file = "/file/that/will/not/exist"
+            with pytest.raises(OSError):
+                driver.persist()
+
+
 def test_external_zeroconf():
     zeroconf = MagicMock()
     with patch("pyhap.accessory_driver.HAPServer"), patch(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,9 +1,8 @@
 """Tests for pyhap.camera."""
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 from uuid import UUID
 
 from pyhap import camera
-
 
 _OPTIONS = {
     "stream_count": 4,
@@ -13,7 +12,7 @@ _OPTIONS = {
                 camera.VIDEO_CODEC_PARAM_PROFILE_ID_TYPES["BASELINE"],
             ],
             "levels": [
-                camera.VIDEO_CODEC_PARAM_LEVEL_TYPES['TYPE3_1'],
+                camera.VIDEO_CODEC_PARAM_LEVEL_TYPES["TYPE3_1"],
             ],
         },
         "resolutions": [
@@ -30,13 +29,10 @@ _OPTIONS = {
     "audio": {
         "codecs": [
             {
-                'type': 'OPUS',
-                'samplerate': 24,
+                "type": "OPUS",
+                "samplerate": 24,
             },
-            {
-                'type': 'AAC-eld',
-                'samplerate': 16
-            }
+            {"type": "AAC-eld", "samplerate": 16},
         ],
     },
     "srtp": True,
@@ -46,35 +42,43 @@ _OPTIONS = {
 
 def test_init(mock_driver):
     """Test that the camera init properly computes TLV values"""
-    acc = camera.Camera(_OPTIONS, mock_driver, 'Camera')
+    acc = camera.Camera(_OPTIONS, mock_driver, "Camera")
 
-    management = acc.get_service('CameraRTPStreamManagement')
+    management = acc.get_service("CameraRTPStreamManagement")
 
-    assert management.get_characteristic('SupportedRTPConfiguration').get_value() == \
-        'AgEA'
-    assert (management.get_characteristic('SupportedVideoStreamConfiguration')
-                      .get_value() ==
-        'AX4BAQACCQMBAAEBAAIBAAMMAQJAAQIC8AADAg8AAwwBAgAEAgIAAwMCHgADDAECgAICAuA'
-        'BAwIeAAMMAQKAAgICaAEDAh4AAwwBAuABAgJoAQMCHgADDAEC4AECAg4BAwIeAAMMAQJAAQ'
-        'IC8AADAh4AAwwBAkABAgK0AAMCHgA=')
-    assert (management.get_characteristic('SupportedAudioStreamConfiguration')
-                      .get_value() ==
-        'AQ4BAQMCCQEBAQIBAAMBAgEOAQECAgkBAQECAQADAQECAQA=')
+    assert (
+        management.get_characteristic("SupportedRTPConfiguration").get_value() == "AgEA"
+    )
+    assert (
+        management.get_characteristic("SupportedVideoStreamConfiguration").get_value()
+        == "AX4BAQACCQMBAAEBAAIBAAMMAQJAAQIC8AADAg8AAwwBAgAEAgIAAwMCHgADDAECgAICAuA"
+        "BAwIeAAMMAQKAAgICaAEDAh4AAwwBAuABAgJoAQMCHgADDAEC4AECAg4BAwIeAAMMAQJAAQ"
+        "IC8AADAh4AAwwBAkABAgK0AAMCHgA="
+    )
+    assert (
+        management.get_characteristic("SupportedAudioStreamConfiguration").get_value()
+        == "AQ4BAQMCCQEBAQIBAAMBAgEOAQECAgkBAQECAQADAQECAQA="
+    )
 
 
 def test_setup_endpoints(mock_driver):
     """Test that the SetupEndpoint response is computed correctly"""
-    set_endpoint_req = ('ARCszGzBBWNFFY2pdLRQkAaRAxoBAQACDTE5Mi4xNjguMS4xMTQDAjPFBAKs1gQ'
-                        'lAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QEBAAUlAhAKRPSRVa'
-                        'qGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQEBAA==')
+    set_endpoint_req = (
+        "ARCszGzBBWNFFY2pdLRQkAaRAxoBAQACDTE5Mi4xNjguMS4xMTQDAjPFBAKs1gQ"
+        "lAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QEBAAUlAhAKRPSRVa"
+        "qGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQEBAA=="
+    )
 
-    set_endpoint_res = ('ARCszGzBBWNFFY2pdLRQkAaRAgEAAxoBAQACDTE5Mi4xNjguMS4yMjYDAjPFBAK'
-                        's1gQlAQEAAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QUlAQEAAh'
-                        'AKRPSRVaqGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQYBAQcBAQ==')
+    set_endpoint_res = (
+        "ARCszGzBBWNFFY2pdLRQkAaRAgEAAxoBAQACDTE5Mi4xNjguMS4yMjYDAjPFBAK"
+        "s1gQlAQEAAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QUlAQEAAh"
+        "AKRPSRVaqGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQYBAQcBAQ=="
+    )
 
-    acc = camera.Camera(_OPTIONS, mock_driver, 'Camera')
-    setup_endpoints = acc.get_service('CameraRTPStreamManagement')\
-                         .get_characteristic('SetupEndpoints')
+    acc = camera.Camera(_OPTIONS, mock_driver, "Camera")
+    setup_endpoints = acc.get_service("CameraRTPStreamManagement").get_characteristic(
+        "SetupEndpoints"
+    )
     setup_endpoints.client_update_value(set_endpoint_req)
 
     assert setup_endpoints.get_value()[:171] == set_endpoint_res[:171]
@@ -98,39 +102,41 @@ def test_set_selected_stream_start_stop(mock_driver):
         process_mock.wait = wait
         return process_mock
 
-    selected_config_req = ('ARUCAQEBEKzMbMEFY0UVjal0tFCQBpECNAEBAAIJAQEAAgEAAwEAAwsBAoAC'
-                           'AgJoAQMBHgQXAQFjAgQr66FSAwKEAAQEAAAAPwUCYgUDLAEBAgIMAQEBAgEA'
-                           'AwEBBAEeAxYBAW4CBMUInmQDAhgABAQAAKBABgENBAEA')
+    selected_config_req = (
+        "ARUCAQEBEKzMbMEFY0UVjal0tFCQBpECNAEBAAIJAQEAAgEAAwEAAwsBAoAC"
+        "AgJoAQMBHgQXAQFjAgQr66FSAwKEAAQEAAAAPwUCYgUDLAEBAgIMAQEBAgEA"
+        "AwEBBAEeAxYBAW4CBMUInmQDAhgABAQAAKBABgENBAEA"
+    )
 
-    session_id = UUID('accc6cc1-0563-4515-8da9-74b450900691')
+    session_id = UUID("accc6cc1-0563-4515-8da9-74b450900691")
 
     session_info = {
-        'id': session_id,
-        'stream_idx': 0,
-        'address': '192.168.1.114',
-        'v_port': 50483,
-        'v_srtp_key': '2JZgpMkwWUH8ahUtzp8VThtBmbk26hCPJqeWpYDR',
-        'a_port': 54956,
-        'a_srtp_key': 'CkT0kVWqhnjZhEkyKI8TYvxaSNMu0a/TBpacuj2B',
-        'process': None
+        "id": session_id,
+        "stream_idx": 0,
+        "address": "192.168.1.114",
+        "v_port": 50483,
+        "v_srtp_key": "2JZgpMkwWUH8ahUtzp8VThtBmbk26hCPJqeWpYDR",
+        "a_port": 54956,
+        "a_srtp_key": "CkT0kVWqhnjZhEkyKI8TYvxaSNMu0a/TBpacuj2B",
+        "process": None,
     }
 
-    acc = camera.Camera(_OPTIONS, mock_driver, 'Camera')
+    acc = camera.Camera(_OPTIONS, mock_driver, "Camera")
 
     acc.sessions[session_id] = session_info
 
-    patcher = patch('asyncio.create_subprocess_exec', new=subprocess_exec)
+    patcher = patch("asyncio.create_subprocess_exec", new=subprocess_exec)
     patcher.start()
 
     acc.set_selected_stream_configuration(selected_config_req)
 
-    assert acc.streaming_status == camera.STREAMING_STATUS['STREAMING']
+    assert acc.streaming_status == camera.STREAMING_STATUS["STREAMING"]
 
-    selected_config_stop_req = 'ARUCAQABEKzMbMEFY0UVjal0tFCQBpE='
+    selected_config_stop_req = "ARUCAQABEKzMbMEFY0UVjal0tFCQBpE="
     acc.set_selected_stream_configuration(selected_config_stop_req)
 
     patcher.stop()
 
     assert session_id not in acc.sessions
     assert process_mock.terminate.called
-    assert acc.streaming_status == camera.STREAMING_STATUS['AVAILABLE']
+    assert acc.streaming_status == camera.STREAMING_STATUS["AVAILABLE"]

--- a/tests/test_characteristic.py
+++ b/tests/test_characteristic.py
@@ -1,48 +1,49 @@
 """Tests for pyhap.characteristic."""
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import ANY, Mock, patch
 from uuid import uuid1
 
 import pytest
 
 from pyhap.characteristic import (
-    Characteristic, HAP_FORMAT_INT, HAP_FORMAT_DEFAULTS, HAP_PERMISSION_READ)
+    HAP_FORMAT_DEFAULTS,
+    HAP_FORMAT_INT,
+    HAP_PERMISSION_READ,
+    Characteristic,
+)
 
-PROPERTIES = {
-    'Format': HAP_FORMAT_INT,
-    'Permissions': [HAP_PERMISSION_READ]
-}
+PROPERTIES = {"Format": HAP_FORMAT_INT, "Permissions": [HAP_PERMISSION_READ]}
 
 
 def get_char(props, valid=None, min_value=None, max_value=None):
     """Return a char object with given parameters."""
     if valid:
-        props['ValidValues'] = valid
+        props["ValidValues"] = valid
     if min_value:
-        props['minValue'] = min_value
+        props["minValue"] = min_value
     if max_value:
-        props['maxValue'] = max_value
-    return Characteristic(display_name='Test Char', type_id=uuid1(),
-                          properties=props)
+        props["maxValue"] = max_value
+    return Characteristic(display_name="Test Char", type_id=uuid1(), properties=props)
 
 
 def test_repr():
     """Test representation of a characteristic."""
     char = get_char(PROPERTIES.copy())
-    del char.properties['Permissions']
-    assert char.__repr__() == \
-        '<characteristic display_name=Test Char value=0 ' \
-        'properties={\'Format\': \'int\'}>'
+    del char.properties["Permissions"]
+    assert (
+        char.__repr__() == "<characteristic display_name=Test Char value=0 "
+        "properties={'Format': 'int'}>"
+    )
 
 
 def test_default_value():
     """Test getting the default value for a specific format."""
     char = get_char(PROPERTIES.copy())
-    assert char.value == HAP_FORMAT_DEFAULTS[PROPERTIES['Format']]
+    assert char.value == HAP_FORMAT_DEFAULTS[PROPERTIES["Format"]]
 
 
 def test_get_default_value():
     """Test getting the default value for valid values."""
-    valid_values = {'foo': 2, 'bar': 3}
+    valid_values = {"foo": 2, "bar": 3}
     char = get_char(PROPERTIES.copy(), valid=valid_values)
     assert char.value == 2
     assert char.value in valid_values.values()
@@ -52,47 +53,48 @@ def test_get_default_value():
 
 def test_to_valid_value():
     """Test function to test if value is valid and saved correctly."""
-    char = get_char(PROPERTIES.copy(), valid={'foo': 2, 'bar': 3},
-                    min_value=2, max_value=7)
+    char = get_char(
+        PROPERTIES.copy(), valid={"foo": 2, "bar": 3}, min_value=2, max_value=7
+    )
     with pytest.raises(ValueError):
         char.to_valid_value(1)
     assert char.to_valid_value(2) == 2
 
-    del char.properties['ValidValues']
-    for value in ('2', None):
+    del char.properties["ValidValues"]
+    for value in ("2", None):
         with pytest.raises(ValueError):
             char.to_valid_value(value)
     assert char.to_valid_value(1) == 2
     assert char.to_valid_value(5) == 5
     assert char.to_valid_value(8) == 7
 
-    char.properties['Format'] = 'string'
-    assert char.to_valid_value(24) == '24'
+    char.properties["Format"] = "string"
+    assert char.to_valid_value(24) == "24"
 
-    char.properties['Format'] = 'bool'
+    char.properties["Format"] = "bool"
     assert char.to_valid_value(1) is True
     assert char.to_valid_value(0) is False
 
-    char.properties['Format'] = 'dictionary'
-    assert char.to_valid_value({'a': 1}) == {'a': 1}
+    char.properties["Format"] = "dictionary"
+    assert char.to_valid_value({"a": 1}) == {"a": 1}
 
 
 def test_override_properties_properties():
     """Test if overriding the properties works."""
-    new_properties = {'minValue': 10, 'maxValue': 20, 'step': 1}
+    new_properties = {"minValue": 10, "maxValue": 20, "step": 1}
     char = get_char(PROPERTIES.copy(), min_value=0, max_value=1)
     char.override_properties(properties=new_properties)
-    assert char.properties['minValue'] == new_properties['minValue']
-    assert char.properties['maxValue'] == new_properties['maxValue']
-    assert char.properties['step'] == new_properties['step']
+    assert char.properties["minValue"] == new_properties["minValue"]
+    assert char.properties["maxValue"] == new_properties["maxValue"]
+    assert char.properties["step"] == new_properties["step"]
 
 
 def test_override_properties_valid_values():
     """Test if overriding the properties works for valid values."""
-    new_valid_values = {'foo2': 2, 'bar2': 3}
-    char = get_char(PROPERTIES.copy(), valid={'foo': 1, 'bar': 2})
+    new_valid_values = {"foo2": 2, "bar2": 3}
+    char = get_char(PROPERTIES.copy(), valid={"foo": 1, "bar": 2})
     char.override_properties(valid_values=new_valid_values)
-    assert char.properties['ValidValues'] == new_valid_values
+    assert char.properties["ValidValues"] == new_valid_values
 
 
 def test_override_properties_error():
@@ -104,7 +106,7 @@ def test_override_properties_error():
 
 def test_set_value():
     """Test setting the value of a characteristic."""
-    path = 'pyhap.characteristic.Characteristic.notify'
+    path = "pyhap.characteristic.Characteristic.notify"
     char = get_char(PROPERTIES.copy(), min_value=3, max_value=7)
 
     with patch(path) as mock_notify:
@@ -124,13 +126,13 @@ def test_set_value():
 
 def test_client_update_value():
     """Test updating the characteristic value with call from the driver."""
-    path_notify = 'pyhap.characteristic.Characteristic.notify'
+    path_notify = "pyhap.characteristic.Characteristic.notify"
     char = get_char(PROPERTIES.copy())
 
     with patch(path_notify) as mock_notify:
         char.client_update_value(4)
         assert char.value == 4
-        with patch.object(char, 'setter_callback') as mock_callback:
+        with patch.object(char, "setter_callback") as mock_callback:
             char.client_update_value(3)
 
     assert char.value == 3
@@ -151,11 +153,11 @@ def test_notify():
     with pytest.raises(AttributeError):
         char.notify()
 
-    with patch.object(char, 'broker') as mock_broker:
+    with patch.object(char, "broker") as mock_broker:
         char.notify()
     mock_broker.publish.assert_called_with(2, char, None)
 
-    with patch.object(char, 'broker') as mock_broker:
+    with patch.object(char, "broker") as mock_broker:
         char.notify("mock_client_addr")
     mock_broker.publish.assert_called_with(2, char, "mock_client_addr")
 
@@ -163,78 +165,79 @@ def test_notify():
 def test_to_HAP_numberic():
     """Test created HAP representation for numeric formats."""
     char = get_char(PROPERTIES.copy(), min_value=1, max_value=2)
-    with patch.object(char, 'broker') as mock_broker:
+    with patch.object(char, "broker") as mock_broker:
         mock_iid = mock_broker.iid_manager.get_iid
         mock_iid.return_value = 2
         hap_repr = char.to_HAP()
         mock_iid.assert_called_with(char)
 
     assert hap_repr == {
-        'iid': 2,
-        'type': ANY,
-        'description': 'Test Char',
-        'perms': ['pr'],
-        'format': 'int',
-        'maxValue': 2,
-        'minValue': 1,
-        'value': 1,
+        "iid": 2,
+        "type": ANY,
+        "description": "Test Char",
+        "perms": ["pr"],
+        "format": "int",
+        "maxValue": 2,
+        "minValue": 1,
+        "value": 1,
     }
 
 
 def test_to_HAP_valid_values():
     """Test created HAP representation for valid values constraint."""
-    char = get_char(PROPERTIES.copy(), valid={'foo': 0, 'bar': 2, 'baz': 1})
-    with patch.object(char, 'broker') as mock_broker:
+    char = get_char(PROPERTIES.copy(), valid={"foo": 0, "bar": 2, "baz": 1})
+    with patch.object(char, "broker") as mock_broker:
         mock_broker.iid_manager.get_iid.return_value = 2
 
         hap_repr = char.to_HAP()
 
-    assert 'valid-values' in hap_repr
-    assert hap_repr['valid-values'] == [0, 1, 2]
+    assert "valid-values" in hap_repr
+    assert hap_repr["valid-values"] == [0, 1, 2]
 
 
 def test_to_HAP_string():
     """Test created HAP representation for strings."""
     char = get_char(PROPERTIES.copy())
-    char.properties['Format'] = 'string'
-    char.value = 'aaa'
-    with patch.object(char, 'broker'):
+    char.properties["Format"] = "string"
+    char.value = "aaa"
+    with patch.object(char, "broker"):
         hap_repr = char.to_HAP()
-    assert hap_repr['format'] == 'string'
-    assert 'maxLen' not in hap_repr
+    assert hap_repr["format"] == "string"
+    assert "maxLen" not in hap_repr
 
-    char.value = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee' \
-        'ffffffffffgggggggggg'
-    with patch.object(char, 'broker'):
+    char.value = (
+        "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggggggggg"
+    )
+    with patch.object(char, "broker"):
         hap_repr = char.to_HAP()
-    assert hap_repr['maxLen'] == 70
-    assert hap_repr['value'] == char.value
+    assert hap_repr["maxLen"] == 70
+    assert hap_repr["value"] == char.value
 
 
 def test_to_HAP_bool():
     """Test created HAP representation for booleans."""
     char = get_char(PROPERTIES.copy())
-    char.properties['Format'] = 'bool'
-    with patch.object(char, 'broker'):
+    char.properties["Format"] = "bool"
+    with patch.object(char, "broker"):
         hap_repr = char.to_HAP()
-    assert hap_repr['format'] == 'bool'
+    assert hap_repr["format"] == "bool"
 
-    char.properties['Permissions'] = []
-    with patch.object(char, 'broker'):
+    char.properties["Permissions"] = []
+    with patch.object(char, "broker"):
         hap_repr = char.to_HAP()
-    assert 'value' not in hap_repr
+    assert "value" not in hap_repr
 
 
 def test_from_dict():
     """Test creating a characteristic object from a dictionary."""
     uuid = uuid1()
     json_dict = {
-        'UUID': str(uuid),
-        'Format': 'int',
-        'Permissions': 'read',
+        "UUID": str(uuid),
+        "Format": "int",
+        "Permissions": "read",
     }
 
-    char = Characteristic.from_dict('Test Char', json_dict)
-    assert char.display_name == 'Test Char'
+    char = Characteristic.from_dict("Test Char", json_dict)
+    assert char.display_name == "Test Char"
     assert char.type_id == uuid
-    assert char.properties == {'Format': 'int', 'Permissions': 'read'}
+    assert char.properties == {"Format": "int", "Permissions": "read"}

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -4,9 +4,9 @@ import uuid
 
 import ed25519
 
-from pyhap.util import generate_mac
-from pyhap.state import State
 import pyhap.encoder as encoder
+from pyhap.state import State
+from pyhap.util import generate_mac
 
 
 def test_persist_and_load():

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -1,0 +1,293 @@
+"""Tests for the HAPServerHandler."""
+
+
+from uuid import UUID
+
+import pytest
+
+from pyhap import hap_handler
+from pyhap.accessory import Accessory
+import pyhap.tlv as tlv
+
+CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
+PUBLIC_KEY = b"\x99\x98d%\x8c\xf6h\x06\xfa\x85\x9f\x90\x82\xf2\xe8\x18\x9f\xf8\xc75\x1f>~\xc32\xc1OC\x13\xbfH\xad"
+
+
+def test_response():
+    """Test object creation of HAPResponse."""
+    response = hap_handler.HAPResponse()
+    assert response.status_code == 500
+    assert "500" in str(response)
+
+
+def test_list_pairings_unencrypted(driver):
+    """Verify an unencrypted list pairings request fails."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = False
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.REQUEST_TYPE, hap_handler.HAP_TLV_STATES.M5
+    )
+    handler.handle_pairings()
+
+    tlv_objects = tlv.decode(response.body)
+
+    assert tlv_objects == {
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM: hap_handler.HAP_TLV_STATES.M2,
+        hap_handler.HAP_TLV_TAGS.ERROR_CODE: hap_handler.HAP_TLV_ERRORS.AUTHENTICATION,
+    }
+
+
+def test_list_pairings(driver):
+    """Verify an encrypted list pairings request."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.REQUEST_TYPE, hap_handler.HAP_TLV_STATES.M5
+    )
+    handler.handle_pairings()
+
+    tlv_objects = tlv.decode(response.body)
+
+    assert tlv_objects == {
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM: hap_handler.HAP_TLV_STATES.M2,
+        hap_handler.HAP_TLV_TAGS.USERNAME: str(CLIENT_UUID).encode("utf8"),
+        hap_handler.HAP_TLV_TAGS.PUBLIC_KEY: PUBLIC_KEY,
+        hap_handler.HAP_TLV_TAGS.PERMISSIONS: hap_handler.HAP_PERMISSIONS.ADMIN,
+    }
+
+
+def test_add_pairing(driver):
+    """Verify an encrypted add pairing request."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.REQUEST_TYPE,
+        hap_handler.HAP_TLV_STATES.M3,
+        hap_handler.HAP_TLV_TAGS.USERNAME,
+        str(CLIENT_UUID).encode("utf-8"),
+        hap_handler.HAP_TLV_TAGS.PUBLIC_KEY,
+        PUBLIC_KEY,
+        hap_handler.HAP_TLV_TAGS.PERMISSIONS,
+        hap_handler.HAP_PERMISSIONS.ADMIN,
+    )
+    assert driver.state.paired is False
+
+    handler.handle_pairings()
+    assert tlv.decode(response.body) == {
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM: hap_handler.HAP_TLV_STATES.M2
+    }
+    assert driver.state.paired is True
+    assert CLIENT_UUID in driver.state.paired_clients
+
+
+def test_remove_pairing(driver):
+    """Verify an encrypted remove pairing request."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert driver.state.paired is True
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    for _ in range(2):
+        response = hap_handler.HAPResponse()
+        handler.response = response
+        handler.request_body = tlv.encode(
+            hap_handler.HAP_TLV_TAGS.REQUEST_TYPE,
+            hap_handler.HAP_TLV_STATES.M4,
+            hap_handler.HAP_TLV_TAGS.USERNAME,
+            str(CLIENT_UUID).encode("utf-8"),
+            hap_handler.HAP_TLV_TAGS.PUBLIC_KEY,
+            PUBLIC_KEY,
+        )
+        handler.handle_pairings()
+        assert tlv.decode(response.body) == {
+            hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM: hap_handler.HAP_TLV_STATES.M2
+        }
+        assert CLIENT_UUID not in driver.state.paired_clients
+        assert driver.state.paired is False
+
+
+def test_invalid_pairings_request(driver):
+    """Verify an encrypted invalid pairings request."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.REQUEST_TYPE, hap_handler.HAP_TLV_STATES.M6
+    )
+
+    with pytest.raises(ValueError):
+        handler.handle_pairings()
+
+
+def test_pair_verify_one(driver):
+    """Verify an unencrypted pair verify one."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = False
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM,
+        hap_handler.HAP_TLV_STATES.M1,
+        hap_handler.HAP_TLV_TAGS.PUBLIC_KEY,
+        PUBLIC_KEY,
+    )
+    handler.handle_pair_verify()
+
+    tlv_objects = tlv.decode(response.body)
+
+    assert (
+        tlv_objects[hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM]
+        == hap_handler.HAP_TLV_STATES.M2
+    )
+
+
+def test_pair_verify_one_not_paired(driver):
+    """Verify an unencrypted pair verify one."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = False
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM,
+        hap_handler.HAP_TLV_STATES.M1,
+        hap_handler.HAP_TLV_TAGS.PUBLIC_KEY,
+        PUBLIC_KEY,
+    )
+    with pytest.raises(hap_handler.NotAllowedInStateException):
+        handler.handle_pair_verify()
+
+
+def test_pair_verify_two_invaild_state(driver):
+    """Verify an unencrypted pair verify two."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = False
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM,
+        hap_handler.HAP_TLV_STATES.M1,
+        hap_handler.HAP_TLV_TAGS.PUBLIC_KEY,
+        PUBLIC_KEY,
+    )
+    handler.handle_pair_verify()
+
+    tlv_objects = tlv.decode(response.body)
+
+    assert (
+        tlv_objects[hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM]
+        == hap_handler.HAP_TLV_STATES.M2
+    )
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM,
+        hap_handler.HAP_TLV_STATES.M3,
+        hap_handler.HAP_TLV_TAGS.ENCRYPTED_DATA,
+        b"invalid",
+    )
+    handler.handle_pair_verify()
+
+    tlv_objects = tlv.decode(response.body)
+
+    assert tlv_objects == {
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM: hap_handler.HAP_TLV_STATES.M4,
+        hap_handler.HAP_TLV_TAGS.ERROR_CODE: hap_handler.HAP_TLV_ERRORS.AUTHENTICATION,
+    }
+
+
+def test_handle_set_handle_set_characteristics_unencrypted(driver):
+    """Verify an unencrypted set_characteristics."""
+    acc = Accessory(driver, "TestAcc", aid=1)
+    assert acc.aid == 1
+    service = acc.driver.loader.get_service("GarageDoorOpener")
+    acc.add_service(service)
+    driver.add_accessory(acc)
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = False
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = b'{"characteristics":[{"aid":1,"iid":9,"ev":true}]}'
+    handler.handle_set_characteristics()
+
+    assert response.status_code == 401
+
+
+def test_handle_set_handle_set_characteristics_encrypted(driver):
+    """Verify an encrypted set_characteristics."""
+    acc = Accessory(driver, "TestAcc", aid=1)
+    assert acc.aid == 1
+    service = acc.driver.loader.get_service("GarageDoorOpener")
+    acc.add_service(service)
+    driver.add_accessory(acc)
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = b'{"characteristics":[{"aid":1,"iid":9,"ev":true}]}'
+    handler.handle_set_characteristics()
+
+    assert response.status_code == 204
+    assert response.body == b""

--- a/tests/test_hap_protocol.py
+++ b/tests/test_hap_protocol.py
@@ -7,6 +7,7 @@ import pytest
 
 from pyhap import hap_protocol
 from pyhap.accessory import Accessory
+from pyhap.hap_handler import HAPResponse
 
 
 class MockHAPCrypto:
@@ -37,6 +38,7 @@ def test_connection_management(driver):
     addr_info = ("1.2.3.4", 5)
     transport = MagicMock(get_extra_info=Mock(return_value=addr_info))
     connections = {}
+    driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
     hap_proto.connection_made(transport)
@@ -57,6 +59,7 @@ def test_pair_setup(driver):
     loop = MagicMock()
     transport = MagicMock()
     connections = {}
+    driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
     hap_proto.connection_made(transport)
@@ -76,6 +79,7 @@ def test_http10_close(driver):
     loop = MagicMock()
     transport = MagicMock()
     connections = {}
+    driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
     hap_proto.connection_made(transport)
@@ -96,6 +100,7 @@ def test_pair_setup_split_between_packets(driver):
     loop = MagicMock()
     transport = MagicMock()
     connections = {}
+    driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
     hap_proto.connection_made(transport)
@@ -119,6 +124,7 @@ def test_get_accessories_without_crypto(driver):
     loop = MagicMock()
     transport = MagicMock()
     connections = {}
+    driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
     hap_proto.connection_made(transport)
@@ -137,7 +143,6 @@ def test_get_accessories_with_crypto(driver):
     loop = MagicMock()
     transport = MagicMock()
     connections = {}
-
     driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
@@ -262,6 +267,7 @@ def test_http_11_keep_alive(driver):
     loop = MagicMock()
     transport = MagicMock()
     connections = {}
+    driver.add_accessory(Accessory(driver, "TestAcc"))
 
     hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
     hap_proto.connection_made(transport)
@@ -363,4 +369,73 @@ async def test_camera_snapshot_works_async(driver):
 
     assert b"fakesnap" in writer.call_args_list[0][0][0]
 
+    hap_proto.close()
+
+
+def test_upgrade_to_encrypted(driver):
+    """Test we switch to encrypted wen we get a shared_key."""
+    loop = MagicMock()
+    transport = MagicMock()
+    connections = {}
+
+    acc = Accessory(driver, "TestAcc")
+    driver.add_accessory(acc)
+
+    hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
+    hap_proto.connection_made(transport)
+
+    assert hap_proto.hap_crypto is None
+
+    def _make_response(*_):
+        response = HAPResponse()
+        response.shared_key = b"newkey"
+        return response
+
+    with patch.object(hap_proto.transport, "write"), patch.object(
+        hap_proto.handler, "dispatch", _make_response
+    ):
+        hap_proto.data_received(
+            b"POST /pair-setup HTTP/1.1\r\nHost: Bridge\\032C77C47._hap._tcp.local\r\nContent-Length: 6\r\nContent-Type: application/pairing+tlv8\r\n\r\n\x00\x01\x00\x06\x01\x01"  # pylint: disable=line-too-long
+        )
+
+    assert hap_proto.hap_crypto is not None
+
+    hap_proto.close()
+
+
+@pytest.mark.asyncio
+async def test_pairing_changed(driver):
+    """Test we update mdns when the pairing changes."""
+    loop = MagicMock()
+
+    run_in_executor_called = False
+
+    async def _run_in_executor(*_):
+        nonlocal run_in_executor_called
+        run_in_executor_called = True
+
+    loop.run_in_executor = _run_in_executor
+    transport = MagicMock()
+    connections = {}
+
+    acc = Accessory(driver, "TestAcc")
+    driver.add_accessory(acc)
+
+    hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
+    hap_proto.connection_made(transport)
+
+    def _make_response(*_):
+        response = HAPResponse()
+        response.pairing_changed = True
+        return response
+
+    with patch.object(hap_proto.transport, "write"), patch.object(
+        hap_proto.handler, "dispatch", _make_response
+    ):
+        hap_proto.data_received(
+            b"POST /pair-setup HTTP/1.1\r\nHost: Bridge\\032C77C47._hap._tcp.local\r\nContent-Length: 6\r\nContent-Type: application/pairing+tlv8\r\n\r\n\x00\x01\x00\x06\x01\x01"  # pylint: disable=line-too-long
+        )
+        await asyncio.sleep(0)
+
+    assert run_in_executor_called is True
     hap_proto.close()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,8 +3,8 @@ import pytest
 
 from pyhap import CHARACTERISTICS_FILE, SERVICES_FILE
 from pyhap.characteristic import Characteristic
+from pyhap.loader import Loader, get_loader
 from pyhap.service import Service
-from pyhap.loader import get_loader, Loader
 
 
 def test_loader_char():
@@ -12,28 +12,28 @@ def test_loader_char():
     loader = Loader()
 
     with pytest.raises(KeyError):
-        loader.get_char('Not a char')
+        loader.get_char("Not a char")
 
-    char_name = loader.get_char('Name')
+    char_name = loader.get_char("Name")
     assert char_name is not None
     assert isinstance(char_name, Characteristic)
 
 
 def test_loader_get_char_error():
     """Test if errors are thrown for invalid dictionary entries."""
-    loader = Loader.from_dict(char_dict={'Char': None})
-    assert loader.char_types == {'Char': None}
+    loader = Loader.from_dict(char_dict={"Char": None})
+    assert loader.char_types == {"Char": None}
     assert loader.serv_types == {}
     json_dicts = (
-        {'Format': 'int', 'Permissions': 'read'},
-        {'Format': 'int', 'UUID': '123456'},
-        {'Permissions': 'read', 'UUID': '123456'}
+        {"Format": "int", "Permissions": "read"},
+        {"Format": "int", "UUID": "123456"},
+        {"Permissions": "read", "UUID": "123456"},
     )
 
     for case in json_dicts:
-        loader.char_types['Char'] = case
+        loader.char_types["Char"] = case
         with pytest.raises(KeyError):
-            loader.get_char('Char')
+            loader.get_char("Char")
 
 
 def test_loader_service():
@@ -41,27 +41,24 @@ def test_loader_service():
     loader = Loader()
 
     with pytest.raises(KeyError):
-        loader.get_service('Not a service')
+        loader.get_service("Not a service")
 
-    serv_acc_info = loader.get_service('AccessoryInformation')
+    serv_acc_info = loader.get_service("AccessoryInformation")
     assert serv_acc_info is not None
     assert isinstance(serv_acc_info, Service)
 
 
 def test_loader_service_error():
     """Test if errors are thrown for invalid dictionary entries."""
-    loader = Loader.from_dict(serv_dict={'Service': None})
+    loader = Loader.from_dict(serv_dict={"Service": None})
     assert loader.char_types == {}
-    assert loader.serv_types == {'Service': None}
-    json_dicts = (
-        {'RequiredCharacteristics': ['Char 1', 'Char 2']},
-        {'UUID': '123456'}
-    )
+    assert loader.serv_types == {"Service": None}
+    json_dicts = ({"RequiredCharacteristics": ["Char 1", "Char 2"]}, {"UUID": "123456"})
 
     for case in json_dicts:
-        loader.serv_types['Service'] = case
+        loader.serv_types["Service"] = case
         with pytest.raises(KeyError):
-            loader.get_service('Service')
+            loader.get_service("Service")
 
 
 def test_get_loader():
@@ -71,8 +68,7 @@ def test_get_loader():
     assert loader.char_types is not ({} or None)
     assert loader.serv_types is not ({} or None)
 
-    loader2 = Loader(path_char=CHARACTERISTICS_FILE,
-                     path_service=SERVICES_FILE)
+    loader2 = Loader(path_char=CHARACTERISTICS_FILE, path_service=SERVICES_FILE)
     assert loader.char_types == loader2.char_types
     assert loader.serv_types == loader2.serv_types
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,13 +1,17 @@
 """Tests for pyhap.service."""
+from unittest.mock import Mock, call, patch
 from uuid import uuid1
-from unittest.mock import call, patch, Mock
 
 import pytest
 
-from pyhap.service import Service
 from pyhap.characteristic import (
-    Characteristic, HAP_FORMAT_INT, HAP_PERMISSION_READ,
-    PROP_FORMAT, PROP_PERMISSIONS)
+    HAP_FORMAT_INT,
+    HAP_PERMISSION_READ,
+    PROP_FORMAT,
+    PROP_PERMISSIONS,
+    Characteristic,
+)
+from pyhap.service import Service
 
 CHAR_PROPS = {
     PROP_FORMAT: HAP_FORMAT_INT,
@@ -17,22 +21,23 @@ CHAR_PROPS = {
 
 def get_chars():
     """Return example char objects."""
-    c1 = Characteristic('Char 1', uuid1(), CHAR_PROPS)
-    c2 = Characteristic('Char 2', uuid1(), CHAR_PROPS)
+    c1 = Characteristic("Char 1", uuid1(), CHAR_PROPS)
+    c2 = Characteristic("Char 2", uuid1(), CHAR_PROPS)
     return [c1, c2]
 
 
 def test_repr():
     """Test service representation."""
-    service = Service(uuid1(), 'TestService')
+    service = Service(uuid1(), "TestService")
     service.characteristics = [get_chars()[0]]
-    assert service.__repr__() == \
-        "<service display_name=TestService chars={'Char 1': 0}>"
+    assert (
+        service.__repr__() == "<service display_name=TestService chars={'Char 1': 0}>"
+    )
 
 
 def test_add_characteristic():
     """Test adding characteristics to a service."""
-    service = Service(uuid1(), 'Test Service')
+    service = Service(uuid1(), "Test Service")
     chars = get_chars()
     service.add_characteristic(*chars)
     for char_service, char_original in zip(service.characteristics, chars):
@@ -44,58 +49,59 @@ def test_add_characteristic():
 
 def test_get_characteristic():
     """Test getting a characteristic from a service."""
-    service = Service(uuid1(), 'Test Service')
+    service = Service(uuid1(), "Test Service")
     chars = get_chars()
     service.characteristics = chars
-    assert service.get_characteristic('Char 1') == chars[0]
+    assert service.get_characteristic("Char 1") == chars[0]
     with pytest.raises(ValueError):
-        service.get_characteristic('Not found')
+        service.get_characteristic("Not found")
 
 
 def test_configure_char():
     """Test preconfiguring a characteristic from a service."""
-    pyhap_char = 'pyhap.characteristic.Characteristic'
+    pyhap_char = "pyhap.characteristic.Characteristic"
 
-    service = Service(uuid1(), 'Test Service')
+    service = Service(uuid1(), "Test Service")
     chars = get_chars()
     service.characteristics = chars
 
     with pytest.raises(ValueError):
-        service.configure_char('Char not found')
-    assert service.configure_char('Char 1') == chars[0]
+        service.configure_char("Char not found")
+    assert service.configure_char("Char 1") == chars[0]
 
-    with patch(pyhap_char + '.override_properties') as mock_override_prop, \
-            patch(pyhap_char + '.set_value') as mock_set_value:
-        service.configure_char('Char 1')
+    with patch(pyhap_char + ".override_properties") as mock_override_prop, patch(
+        pyhap_char + ".set_value"
+    ) as mock_set_value:
+        service.configure_char("Char 1")
         mock_override_prop.assert_not_called()
         mock_set_value.assert_not_called()
-        assert service.get_characteristic('Char 1').setter_callback is None
+        assert service.get_characteristic("Char 1").setter_callback is None
 
-    with patch(pyhap_char + '.override_properties') as mock_override_prop:
-        new_properties = {'Format': 'string'}
-        new_valid_values = {0: 'on', 1: 'off'}
-        service.configure_char('Char 1', properties=new_properties)
+    with patch(pyhap_char + ".override_properties") as mock_override_prop:
+        new_properties = {"Format": "string"}
+        new_valid_values = {0: "on", 1: "off"}
+        service.configure_char("Char 1", properties=new_properties)
         mock_override_prop.assert_called_with(new_properties, None)
-        service.configure_char('Char 1', valid_values=new_valid_values)
+        service.configure_char("Char 1", valid_values=new_valid_values)
         mock_override_prop.assert_called_with(None, new_valid_values)
-        service.configure_char('Char 1', properties=new_properties,
-                               valid_values=new_valid_values)
+        service.configure_char(
+            "Char 1", properties=new_properties, valid_values=new_valid_values
+        )
         mock_override_prop.assert_called_with(new_properties, new_valid_values)
 
-    with patch(pyhap_char + '.set_value') as mock_set_value:
+    with patch(pyhap_char + ".set_value") as mock_set_value:
         new_value = 1
-        service.configure_char('Char 1', value=new_value)
+        service.configure_char("Char 1", value=new_value)
         mock_set_value.assert_called_with(1, should_notify=False)
 
-    new_setter_callback = 'Test callback'
-    service.configure_char('Char 1', setter_callback=new_setter_callback)
-    assert service.get_characteristic('Char 1').setter_callback == \
-        new_setter_callback
+    new_setter_callback = "Test callback"
+    service.configure_char("Char 1", setter_callback=new_setter_callback)
+    assert service.get_characteristic("Char 1").setter_callback == new_setter_callback
 
 
 def test_is_primary_service():
     """Test setting is_primary_service on a service."""
-    service = Service(uuid1(), 'Test Service')
+    service = Service(uuid1(), "Test Service")
 
     assert service.is_primary_service is None
 
@@ -108,10 +114,10 @@ def test_is_primary_service():
 
 def test_add_linked_service():
     """Test adding linked service to a service."""
-    service = Service(uuid1(), 'Test Service')
+    service = Service(uuid1(), "Test Service")
     assert len(service.linked_services) == 0
 
-    linked_service = Service(uuid1(), 'Test Linked Service')
+    linked_service = Service(uuid1(), "Test Linked Service")
     service.add_linked_service(linked_service)
 
     assert len(service.linked_services) == 1
@@ -121,74 +127,76 @@ def test_add_linked_service():
 def test_to_HAP():
     """Test created HAP representation of a service."""
     uuid = uuid1()
-    pyhap_char_to_HAP = 'pyhap.characteristic.Characteristic.to_HAP'
+    pyhap_char_to_HAP = "pyhap.characteristic.Characteristic.to_HAP"
 
-    service = Service(uuid, 'Test Service')
+    service = Service(uuid, "Test Service")
     service.characteristics = get_chars()
-    with patch(pyhap_char_to_HAP) as mock_char_HAP, \
-            patch.object(service, 'broker') as mock_broker:
+    with patch(pyhap_char_to_HAP) as mock_char_HAP, patch.object(
+        service, "broker"
+    ) as mock_broker:
         mock_iid = mock_broker.iid_manager.get_iid
         mock_iid.return_value = 2
-        mock_char_HAP.side_effect = ('Char 1', 'Char 2')
+        mock_char_HAP.side_effect = ("Char 1", "Char 2")
         hap_repr = service.to_HAP()
         mock_iid.assert_called_with(service)
 
     assert hap_repr == {
-        'iid': 2,
-        'type': str(uuid).upper(),
-        'characteristics': ['Char 1', 'Char 2'],
+        "iid": 2,
+        "type": str(uuid).upper(),
+        "characteristics": ["Char 1", "Char 2"],
     }
 
 
 def test_linked_service_to_HAP():
     """Test created HAP representation of a service."""
     uuid = uuid1()
-    pyhap_char_to_HAP = 'pyhap.characteristic.Characteristic.to_HAP'
+    pyhap_char_to_HAP = "pyhap.characteristic.Characteristic.to_HAP"
 
-    service = Service(uuid, 'Test Service')
-    linked_service = Service(uuid1(), 'Test Linked Service')
+    service = Service(uuid, "Test Service")
+    linked_service = Service(uuid1(), "Test Linked Service")
     service.add_linked_service(linked_service)
     service.characteristics = get_chars()
-    with patch(pyhap_char_to_HAP) as mock_char_HAP, \
-            patch.object(service, 'broker') as mock_broker, \
-            patch.object(linked_service, 'broker') as mock_linked_broker:
+    with patch(pyhap_char_to_HAP) as mock_char_HAP, patch.object(
+        service, "broker"
+    ) as mock_broker, patch.object(linked_service, "broker") as mock_linked_broker:
         mock_iid = mock_broker.iid_manager.get_iid
         mock_iid.return_value = 2
         mock_linked_iid = mock_linked_broker.iid_manager.get_iid
         mock_linked_iid.return_value = 3
-        mock_char_HAP.side_effect = ('Char 1', 'Char 2')
+        mock_char_HAP.side_effect = ("Char 1", "Char 2")
         hap_repr = service.to_HAP()
         mock_iid.assert_called_with(service)
 
     assert hap_repr == {
-        'iid': 2,
-        'type': str(uuid).upper(),
-        'characteristics': ['Char 1', 'Char 2'],
-        'linked': [mock_linked_iid()],
+        "iid": 2,
+        "type": str(uuid).upper(),
+        "characteristics": ["Char 1", "Char 2"],
+        "linked": [mock_linked_iid()],
     }
 
 
 def test_is_primary_service_to_HAP():
     """Test created HAP representation of primary service."""
     uuid = uuid1()
-    pyhap_char_to_HAP = 'pyhap.characteristic.Characteristic.to_HAP'
+    pyhap_char_to_HAP = "pyhap.characteristic.Characteristic.to_HAP"
 
-    service = Service(uuid, 'Test Service')
+    service = Service(uuid, "Test Service")
     service.characteristics = get_chars()
     service.is_primary_service = True
-    with patch(pyhap_char_to_HAP) as mock_char_HAP, \
-            patch.object(service, 'broker') as mock_broker:
+    with patch(pyhap_char_to_HAP) as mock_char_HAP, patch.object(
+        service, "broker"
+    ) as mock_broker:
         mock_iid = mock_broker.iid_manager.get_iid
         mock_iid.return_value = 2
-        mock_char_HAP.side_effect = ('Char 1', 'Char 2')
+        mock_char_HAP.side_effect = ("Char 1", "Char 2")
         hap_repr = service.to_HAP()
         mock_iid.assert_called_with(service)
 
     assert hap_repr == {
-        'iid': 2,
-        'type': str(uuid).upper(),
-        'characteristics': ['Char 1', 'Char 2'],
-        'primary': True
+        "iid": 2,
+        "type": str(uuid).upper(),
+        "characteristics": ["Char 1", "Char 2"],
+        "primary": True,
     }
 
 
@@ -200,17 +208,18 @@ def test_from_dict():
     mock_char_loader.get_char.side_effect = chars
 
     json_dict = {
-        'UUID': str(uuid),
-        'RequiredCharacteristics': {
-            'Char 1',
-            'Char 2',
-        }
+        "UUID": str(uuid),
+        "RequiredCharacteristics": {
+            "Char 1",
+            "Char 2",
+        },
     }
 
-    service = Service.from_dict('Test Service', json_dict, mock_char_loader)
-    assert service.display_name == 'Test Service'
+    service = Service.from_dict("Test Service", json_dict, mock_char_loader)
+    assert service.display_name == "Test Service"
     assert service.type_id == uuid
     assert service.characteristics == chars
 
     mock_char_loader.get_char.assert_has_calls(
-        [call('Char 1'), call('Char 2')], any_order=True)
+        [call("Char 1"), call("Char 2")], any_order=True
+    )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,19 +9,20 @@ from pyhap.state import State
 def test_setup():
     """Test if State class is setup correctly."""
     with pytest.raises(TypeError):
-        State('invalid_argument')
+        State("invalid_argument")
 
-    addr = '172.0.0.1'
-    mac = '00:00:00:00:00:00'
-    pin = b'123-45-678'
+    addr = "172.0.0.1"
+    mac = "00:00:00:00:00:00"
+    pin = b"123-45-678"
     port = 11111
 
-    with patch('pyhap.util.get_local_address') as mock_local_addr, \
-        patch('pyhap.util.generate_mac') as mock_gen_mac, \
-        patch('pyhap.util.generate_pincode') as mock_gen_pincode, \
-        patch('pyhap.util.generate_setup_id') as mock_gen_setup_id, \
-        patch('ed25519.create_keypair', return_value=(1, 2)) \
-            as mock_create_keypair:
+    with patch("pyhap.util.get_local_address") as mock_local_addr, patch(
+        "pyhap.util.generate_mac"
+    ) as mock_gen_mac, patch("pyhap.util.generate_pincode") as mock_gen_pincode, patch(
+        "pyhap.util.generate_setup_id"
+    ) as mock_gen_setup_id, patch(
+        "ed25519.create_keypair", return_value=(1, 2)
+    ) as mock_create_keypair:
 
         state = State(address=addr, mac=mac, pincode=pin, port=port)
         assert not mock_local_addr.called
@@ -45,20 +46,20 @@ def test_setup():
 
 def test_pairing():
     """Test if pairing methods work."""
-    with patch('pyhap.util.get_local_address'), \
-        patch('pyhap.util.generate_mac'), \
-        patch('pyhap.util.generate_pincode'), \
-        patch('pyhap.util.generate_setup_id'), \
-            patch('ed25519.create_keypair', return_value=(1, 2)):
+    with patch("pyhap.util.get_local_address"), patch("pyhap.util.generate_mac"), patch(
+        "pyhap.util.generate_pincode"
+    ), patch("pyhap.util.generate_setup_id"), patch(
+        "ed25519.create_keypair", return_value=(1, 2)
+    ):
         state = State()
 
     assert not state.paired
     assert not state.paired_clients
 
-    state.add_paired_client('uuid', 'public')
+    state.add_paired_client("uuid", "public")
     assert state.paired
-    assert state.paired_clients == {'uuid': 'public'}
+    assert state.paired_clients == {"uuid": "public"}
 
-    state.remove_paired_client('uuid')
+    state.remove_paired_client("uuid")
     assert not state.paired
     assert not state.paired_clients

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,8 @@ deps =
     -r{toxinidir}/requirements_all.txt
     -r{toxinidir}/requirements_test.txt
 commands =
-    pylint pyhap tests --disable=missing-docstring,empty-docstring,invalid-name,fixme --max-line-length=120
+    pylint pyhap --disable=missing-docstring,empty-docstring,invalid-name,fixme --max-line-length=120
+    pylint tests --disable=duplicate-code,missing-docstring,empty-docstring,invalid-name,fixme --max-line-length=120
 
 
 [testenv:doc-errors]


### PR DESCRIPTION
Pairing would sometimes fail because list pairings
was not implemented and an exception would be generated.

The state file could get corrupted if something went
wrong with the write. We now write a temp file and
move it in place after its fully written.

Ensure writing the state happens outside
of the event loop.

Also fixes connection stall on camera image failure.

Project test coverage up to 82.65% 

Fixes

```
2021-02-02 08:33:15 ERROR (MainThread) [pyhap.hap_handler] Failed to process request for: /pairings
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pyhap/hap_handler.py", line 207, in dispatch
    getattr(self, self.HANDLERS[self.command][path])()
  File "/usr/local/lib/python3.8/site-packages/pyhap/hap_handler.py", line 608, in handle_pairings
    raise ValueError(
ValueError: Unknown pairing request type of 5 during pair verify
```