### PR TITLE
Speed up new HAP event subscribe on new connections

### DIFF
--- a/pyhap/iid_manager.py
+++ b/pyhap/iid_manager.py
@@ -9,8 +9,9 @@ class IIDManager:
 
     def __init__(self):
         """Initialize an empty instance."""
-        self.iids = {}
         self.counter = 0
+        self.iids = {}
+        self.objs = {}
 
     def assign(self, obj):
         """Assign an IID to given object. Print warning if already assigned.
@@ -20,20 +21,20 @@ class IIDManager:
         """
         if obj in self.iids:
             logger.warning(
-                'The given Service or Characteristic with UUID %s already '
-                'has an assigned IID %s, ignoring.',
-                obj.type_id, self.iids[obj])
+                "The given Service or Characteristic with UUID %s already "
+                "has an assigned IID %s, ignoring.",
+                obj.type_id,
+                self.iids[obj],
+            )
             return
 
         self.counter += 1
         self.iids[obj] = self.counter
+        self.objs[self.counter] = obj
 
     def get_obj(self, iid):
         """Get the object that is assigned the given IID."""
-        for obj, iid_to_obj in self.iids.items():
-            if iid_to_obj == iid:
-                return obj
-        return None
+        return self.objs.get(iid)
 
     def get_iid(self, obj):
         """Get the IID assigned to the given object."""
@@ -43,14 +44,16 @@ class IIDManager:
         """Remove an object from the IID list."""
         iid = self.iids.pop(obj, None)
         if iid is None:
-            logger.error('Object %s not found.', obj)
+            logger.error("Object %s not found.", obj)
+            return None
+        del self.objs[iid]
         return iid
 
     def remove_iid(self, iid):
         """Remove an object with an IID from the IID list."""
-        for obj, iid_to_obj in self.iids.items():
-            if iid_to_obj == iid:
-                del self.iids[obj]
-                return obj
-        logger.error('IID %s not found.', iid)
-        return None
+        obj = self.objs.pop(iid, None)
+        if obj is None:
+            logger.error("IID %s not found.", iid)
+            return None
+        del self.iids[obj]
+        return obj


### PR DESCRIPTION
Avoids the linear search of objects to
find the iid. When there are a lot of
characteristics and accessories on a
bridge, the reconnect could cause the
bridge to go unavailable on slower systems (RPi3)
while it was re-subscribing to events.

We now use a dict lookup to find object
from the iid