### PR TITLE
Properly handle snapshots if camera added to bridge

### DIFF
--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -703,7 +703,6 @@ class HAPServerHandler:
 
     def handle_resource(self):
         """Get a snapshot from the camera."""
-
         data = json.loads(self.request_body.decode("utf-8"))
 
         if self.accessory_handler.accessory.category == CATEGORY_BRIDGE:

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -16,7 +16,7 @@ import ed25519
 
 import pyhap.tlv as tlv
 from pyhap.util import long_to_bytes
-
+from pyhap.const import CATEGORY_BRIDGE
 from .hap_crypto import hap_hkdf, pad_tls_nonce
 
 SNAPSHOT_TIMEOUT = 10
@@ -703,14 +703,23 @@ class HAPServerHandler:
 
     def handle_resource(self):
         """Get a snapshot from the camera."""
-        image_size = json.loads(self.request_body.decode("utf-8"))
+
+        data = json.loads(self.request_body.decode("utf-8"))
+
+        if self.accessory_handler.accessory.category == CATEGORY_BRIDGE:
+            accessory = self.accessory_handler.accessory.accessories.get(data['aid'])
+            if not accessory:
+                raise ValueError('Accessory with aid == {} not found'.format(data['aid']))
+        else:
+            accessory = self.accessory_handler.accessory
+
         loop = asyncio.get_event_loop()
-        if hasattr(self.accessory_handler.accessory, "async_get_snapshot"):
-            coro = self.accessory_handler.accessory.async_get_snapshot(image_size)
-        elif hasattr(self.accessory_handler.accessory, "get_snapshot"):
+        if hasattr(accessory, "async_get_snapshot"):
+            coro = accessory.async_get_snapshot(data)
+        elif hasattr(accessory, "get_snapshot"):
             coro = asyncio.wait_for(
                 loop.run_in_executor(
-                    None, self.accessory_handler.accessory.get_snapshot, image_size
+                    None, accessory.get_snapshot, data
                 ),
                 SNAPSHOT_TIMEOUT,
             )

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import pytest
 
 from pyhap import hap_handler
-from pyhap.accessory import Accessory
+from pyhap.accessory import Accessory, Bridge
 import pyhap.tlv as tlv
 
 CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
@@ -291,3 +291,18 @@ def test_handle_set_handle_set_characteristics_encrypted(driver):
 
     assert response.status_code == 204
     assert response.body == b""
+
+
+def test_handle_snapshot_encrypted_non_existant_accessory(driver):
+    """Verify an encrypted snapshot with non-existant accessory."""
+    bridge = Bridge(driver, "Test Bridge")
+    driver.add_accessory(bridge)
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = b'{"image-height":360,"resource-type":"image","image-width":640,"aid":1411620844}'
+    with pytest.raises(ValueError):
+        handler.handle_resource()


### PR DESCRIPTION
Updated version of #306 pull request to work correctly with 3.2.0, add coverage, and timeout.

The handle_resource method from HAPServer class does not support situation when camera added to bridge and fails with Got a request for snapshot, but the Accessory does not define a "get_snapshot" method error. This is because it tries to check if bridge itself has the get_snapshot method.

This pull request fixes this problem.