### PR TITLE
Resolve unavailable condition on restart

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -35,6 +35,7 @@ from pyhap import util
 from pyhap.accessory import get_topic
 from pyhap.characteristic import CharacteristicError
 from pyhap.const import (
+    MAX_CONFIG_VERSION,
     HAP_PERMISSION_NOTIFY,
     HAP_REPR_ACCS,
     HAP_REPR_AID,
@@ -338,6 +339,7 @@ class AccessoryDriver:
             self.state.address,
             self.state.port,
         )
+
         await self.async_add_job(self.accessory.stop)
 
         logger.debug(
@@ -498,6 +500,8 @@ class AccessoryDriver:
         to fetch new data.
         """
         self.state.config_version += 1
+        if self.state.config_version > MAX_CONFIG_VERSION:
+            self.state.config_version = 1
         self.persist()
         self.update_advertisement()
 

--- a/pyhap/const.py
+++ b/pyhap/const.py
@@ -9,11 +9,12 @@ REQUIRED_PYTHON_VER = (3, 5)
 # ### Misc ###
 STANDALONE_AID = 1  # Standalone accessory ID (i.e. not bridged)
 
-
 # ### Default values ###
 DEFAULT_CONFIG_VERSION = 2
 DEFAULT_PORT = 51827
 
+# ### Configuration version ###
+MAX_CONFIG_VERSION = 65535
 
 # ### CATEGORY values ###
 # Category is a hint to iOS clients about what "type" of Accessory this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,16 @@ def mock_driver():
 
 @pytest.fixture
 def driver():
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     with patch("pyhap.accessory_driver.HAPServer"), patch(
         "pyhap.accessory_driver.Zeroconf"
     ), patch("pyhap.accessory_driver.AccessoryDriver.persist"):
-        yield AccessoryDriver()
+
+        yield AccessoryDriver(loop=loop)
 
 
 class MockDriver:
@@ -30,4 +36,4 @@ class MockDriver:
         pass
 
     def add_job(self, target, *args):  # pylint: disable=no-self-use
-        asyncio.get_event_loop().run_until_complete(target(*args))
+        asyncio.new_event_loop().run_until_complete(target(*args))

--- a/tests/test_hap_protocol.py
+++ b/tests/test_hap_protocol.py
@@ -187,7 +187,12 @@ def test_get_characteristics_with_crypto(driver):
         )
 
     hap_proto.close()
+    assert b"Content-Length:" in writer.call_args_list[0][0][0]
+    assert b"Transfer-Encoding: chunked\r\n\r\n" not in writer.call_args_list[0][0][0]
     assert b"-70402" in writer.call_args_list[0][0][0]
+
+    assert b"Content-Length:" in writer.call_args_list[1][0][0]
+    assert b"Transfer-Encoding: chunked\r\n\r\n" not in writer.call_args_list[1][0][0]
     assert b"TestAcc" in writer.call_args_list[1][0][0]
 
 
@@ -215,7 +220,7 @@ def test_set_characteristics_with_crypto(driver):
         )
 
     hap_proto.close()
-    assert writer.call_args_list[0][0][0] == b"HTTP/1.1 204 OK\r\n\r\n"
+    assert writer.call_args_list[0][0][0] == b"HTTP/1.1 204 No Content\r\n\r\n"
 
 
 def test_crypto_failure_closes_connection(driver):


### PR DESCRIPTION
@ikalchev I thought I had solved this in #316 but it turns out it was the chunked encoding that seems to be the issue. Thanks for doing the 3.3.1 release as I wouldn't have been able to get the debug log that showed the problem since it was only apparent what was happening after a drop that #316 fixed. Sorry, but I think we need another release.

- Avoid sending chunked responses since iOS does not deal with it well
- Fix HTTP Status code strings
- Increase coverage
- Solve overflow on config version

