### PR TITLE
Resolve connection stability with large responses

### DIFF
--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -14,9 +14,10 @@ from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 import curve25519
 import ed25519
 
+from pyhap.const import CATEGORY_BRIDGE
 import pyhap.tlv as tlv
 from pyhap.util import long_to_bytes
-from pyhap.const import CATEGORY_BRIDGE
+
 from .hap_crypto import hap_hkdf, pad_tls_nonce
 
 SNAPSHOT_TIMEOUT = 10
@@ -92,10 +93,6 @@ class HAP_SERVER_STATUS:
 class HAP_PERMISSIONS:
     USER = b"\x00"
     ADMIN = b"\x01"
-
-
-class TimeoutException(Exception):
-    pass
 
 
 class UnprivilegedRequestException(Exception):
@@ -228,8 +225,6 @@ class HAPServerHandler:
             self.send_response_with_status(
                 HTTPStatus.UNAUTHORIZED, HAP_SERVER_STATUS.INSUFFICIENT_PRIVILEGES
             )
-        except TimeoutException:
-            self.send_response_with_status(500, HAP_SERVER_STATUS.OPERATION_TIMED_OUT)
         except Exception:  # pylint: disable=broad-except
             logger.exception(
                 "%s: Failed to process request for: %s", self.client_address, path
@@ -239,11 +234,6 @@ class HAPServerHandler:
                 HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             )
 
-        body_len = len(self.response.body)
-        if body_len:
-            # Force Content-Length as iOS can sometimes
-            # stall if it gets chunked encoding
-            self.send_header("Content-Length", str(body_len))
         self.response = None
         return response
 

--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -4,11 +4,14 @@ The HAPServer is the point of contact to and from the world.
 """
 
 import logging
+import time
 
-from .util import callback
 from .hap_protocol import HAPServerProtocol
+from .util import callback
 
 logger = logging.getLogger(__name__)
+
+IDLE_CONNECTION_CHECK_INTERVAL_SECONDS = 120
 
 
 class HAPServer:
@@ -52,13 +55,27 @@ class HAPServer:
         self.accessory_handler = accessory_handler
         self.server = None
         self._serve_task = None
+        self._connection_cleanup = None
+        self.loop = None
 
     async def async_start(self, loop):
         """Start the http-hap server."""
+        self.loop = loop
         self.server = await loop.create_server(
             lambda: HAPServerProtocol(loop, self.connections, self.accessory_handler),
             self._addr_port[0],
             self._addr_port[1],
+        )
+        self.async_cleanup_connections()
+
+    @callback
+    def async_cleanup_connections(self):
+        """Cleanup stale connections."""
+        now = time.time()
+        for hap_proto in list(self.connections.values()):
+            hap_proto.check_idle(now)
+        self._connection_cleanup = self.loop.call_later(
+            IDLE_CONNECTION_CHECK_INTERVAL_SECONDS, self.async_cleanup_connections
         )
 
     @callback
@@ -72,6 +89,7 @@ class HAPServer:
             if hap_server_protocol:
                 hap_server_protocol.close()
         self.connections.clear()
+        self._connection_cleanup.cancel()
 
     def push_event(self, bytesdata, client_addr):
         """Send an event to the current connection with the provided data.

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -473,9 +473,15 @@ async def test_start_stop_async_acc():
 
 @pytest.mark.asyncio
 async def test_start_from_async_stop_from_executor():
-    with patch("pyhap.accessory_driver.HAPServer"), patch(
+    with patch(
+        "pyhap.accessory_driver.HAPServer.async_stop", new_callable=AsyncMock
+    ), patch(
+        "pyhap.accessory_driver.HAPServer.async_start", new_callable=AsyncMock
+    ), patch(
         "pyhap.accessory_driver.Zeroconf"
-    ), patch("pyhap.accessory_driver.AccessoryDriver.persist"), patch(
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.persist"
+    ), patch(
         "pyhap.accessory_driver.AccessoryDriver.load"
     ):
         driver = AccessoryDriver(loop=asyncio.get_event_loop())

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -1,12 +1,14 @@
 """Tests for the HAPServerHandler."""
 
 
+from unittest.mock import patch
 from uuid import UUID
 
 import pytest
 
 from pyhap import hap_handler
 from pyhap.accessory import Accessory, Bridge
+from pyhap.characteristic import CharacteristicError
 import pyhap.tlv as tlv
 
 CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
@@ -260,6 +262,30 @@ def test_pair_verify_two_invaild_state(driver):
     }
 
 
+def test_invalid_pairing_request(driver):
+    """Verify an unencrypted pair verify with an invalid sequence fails."""
+    driver.add_accessory(Accessory(driver, "TestAcc"))
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = False
+    driver.pair(
+        CLIENT_UUID,
+        PUBLIC_KEY,
+    )
+    assert CLIENT_UUID in driver.state.paired_clients
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.request_body = tlv.encode(
+        hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM,
+        hap_handler.HAP_TLV_STATES.M6,
+        hap_handler.HAP_TLV_TAGS.PUBLIC_KEY,
+        PUBLIC_KEY,
+    )
+    with pytest.raises(ValueError):
+        handler.handle_pair_verify()
+
+
 def test_handle_set_handle_set_characteristics_unencrypted(driver):
     """Verify an unencrypted set_characteristics."""
     acc = Accessory(driver, "TestAcc", aid=1)
@@ -364,3 +390,32 @@ def test_attempt_to_pair_when_already_paired(driver):
         hap_handler.HAP_TLV_TAGS.SEQUENCE_NUM: hap_handler.HAP_TLV_STATES.M2,
         hap_handler.HAP_TLV_TAGS.ERROR_CODE: hap_handler.HAP_TLV_ERRORS.UNAVAILABLE,
     }
+
+
+def test_handle_get_characteristics_encrypted(driver):
+    """Verify an encrypted get_characteristics."""
+    acc = Accessory(driver, "TestAcc", aid=1)
+    assert acc.aid == 1
+    service = acc.driver.loader.get_service("GarageDoorOpener")
+    acc.add_service(service)
+    driver.add_accessory(acc)
+
+    handler = hap_handler.HAPServerHandler(driver, "peername")
+    handler.is_encrypted = True
+
+    response = hap_handler.HAPResponse()
+    handler.response = response
+    handler.path = "/characteristics?id=1.9"
+    handler.handle_get_characteristics()
+
+    assert response.status_code == 207
+    assert b'"value": 0' in response.body
+
+    with patch.object(acc.iid_manager, "get_obj", side_effect=CharacteristicError):
+        response = hap_handler.HAPResponse()
+        handler.response = response
+        handler.path = "/characteristics?id=1.9"
+        handler.handle_get_characteristics()
+
+    assert response.status_code == 207
+    assert b"-70402" in response.body

--- a/tests/test_hap_server.py
+++ b/tests/test_hap_server.py
@@ -1,11 +1,12 @@
 """Tests for the HAPServer."""
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pyhap import hap_server
+from pyhap.accessory_driver import AccessoryDriver
 
 
 @pytest.mark.asyncio
@@ -20,6 +21,33 @@ async def test_we_can_start_stop(driver):
     await server.async_start(loop)
     server.connections[client_1_addr_info] = MagicMock()
     server.connections[client_2_addr_info] = None
+    server.async_stop()
+
+
+@pytest.mark.asyncio
+async def test_idle_connection_cleanup():
+    """Test we cleanup idle connections."""
+    loop = asyncio.get_event_loop()
+    addr_info = ("0.0.0.0", None)
+    client_1_addr_info = ("1.2.3.4", 44433)
+
+    with patch.object(hap_server, "IDLE_CONNECTION_CHECK_INTERVAL_SECONDS", 0), patch(
+        "pyhap.accessory_driver.Zeroconf"
+    ), patch("pyhap.accessory_driver.AccessoryDriver.persist"), patch(
+        "pyhap.accessory_driver.AccessoryDriver.load"
+    ):
+        driver = AccessoryDriver(loop=loop)
+        server = hap_server.HAPServer(addr_info, driver)
+        await server.async_start(loop)
+        check_idle = MagicMock()
+        server.connections[client_1_addr_info] = MagicMock(check_idle=check_idle)
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert check_idle.called
+        check_idle.reset_mock()
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert check_idle.called
     server.async_stop()
 
 


### PR DESCRIPTION
- Increase the write buffer to ensure encrypted responses are written in one shot to avoid connection resets
- Ensure camera snapshots use content-length
- Remove unused timeout code
- Timeout idle connections after 90hrs
- Increase coverage

Should fix https://github.com/home-assistant/core/issues/47152