### PR TITLE
Remove legacy python code

### DIFF
--- a/pyhap/encoder.py
+++ b/pyhap/encoder.py
@@ -8,8 +8,6 @@ import uuid
 
 import ed25519
 
-from pyhap.util import fromhex, tohex
-
 
 class AccessoryEncoder:
     """This class defines the Accessory encoder interface.
@@ -52,14 +50,15 @@ class AccessoryEncoder:
             - UUID and public key of paired clients.
             - Config version.
         """
-        paired_clients = {str(client): tohex(key)
-                          for client, key in state.paired_clients.items()}
+        paired_clients = {
+            str(client): bytes.hex(key) for client, key in state.paired_clients.items()
+        }
         config_state = {
-            'mac': state.mac,
-            'config_version': state.config_version,
-            'paired_clients': paired_clients,
-            'private_key': tohex(state.private_key.to_seed()),
-            'public_key': tohex(state.public_key.to_bytes()),
+            "mac": state.mac,
+            "config_version": state.config_version,
+            "paired_clients": paired_clients,
+            "private_key": bytes.hex(state.private_key.to_seed()),
+            "public_key": bytes.hex(state.public_key.to_bytes()),
         }
         json.dump(config_state, fp)
 
@@ -70,10 +69,11 @@ class AccessoryEncoder:
         @see: AccessoryEncoder.persist
         """
         loaded = json.load(fp)
-        state.mac = loaded['mac']
-        state.config_version = loaded['config_version']
-        state.paired_clients = {uuid.UUID(client): fromhex(key)
-                                for client, key in
-                                loaded['paired_clients'].items()}
-        state.private_key = ed25519.SigningKey(fromhex(loaded['private_key']))
-        state.public_key = ed25519.VerifyingKey(fromhex(loaded['public_key']))
+        state.mac = loaded["mac"]
+        state.config_version = loaded["config_version"]
+        state.paired_clients = {
+            uuid.UUID(client): bytes.fromhex(key)
+            for client, key in loaded["paired_clients"].items()
+        }
+        state.private_key = ed25519.SigningKey(bytes.fromhex(loaded["private_key"]))
+        state.public_key = ed25519.VerifyingKey(bytes.fromhex(loaded["public_key"]))

--- a/pyhap/util.py
+++ b/pyhap/util.py
@@ -1,13 +1,10 @@
 import asyncio
 import base64
-import socket
 import random
-import binascii
-import sys
+import socket
 
-
-ALPHANUM = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-HEX_DIGITS = '0123456789ABCDEF'
+ALPHANUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+HEX_DIGITS = "0123456789ABCDEF"
 
 rand = random.SystemRandom()
 
@@ -65,7 +62,8 @@ def generate_mac():
     :rtype: str
     """
     return "{}{}:{}{}:{}{}:{}{}:{}{}:{}{}".format(
-        *(rand.choice(HEX_DIGITS) for _ in range(12)))
+        *(rand.choice(HEX_DIGITS) for _ in range(12))
+    )
 
 
 def generate_setup_id():
@@ -77,10 +75,7 @@ def generate_setup_id():
     :return: 4 digit alphanumeric code.
     :rtype: str
     """
-    return ''.join([
-        rand.choice(ALPHANUM)
-        for i in range(4)
-    ])
+    return "".join([rand.choice(ALPHANUM) for i in range(4)])
 
 
 def generate_pincode():
@@ -90,50 +85,21 @@ def generate_pincode():
     :return: pincode in format ``xxx-xx-xxx``
     :rtype: bytearray
     """
-    return '{}{}{}-{}{}-{}{}{}'.format(
-        *(rand.randint(0, 9) for i in range(8))
-    ).encode('ascii')
-
-
-def b2hex(bts):
-    """Produce a hex string representation of the given bytes.
-
-    :param bts: bytes to convert to hex.
-    :type bts: bytes
-    :rtype: str
-    """
-    return binascii.hexlify(bts).decode("ascii")
-
-
-def hex2b(hex_str):
-    """Produce bytes from the given hex string representation.
-
-    :param hex: hex string
-    :type hex: str
-    :rtype: bytes
-    """
-    return binascii.unhexlify(hex_str.encode("ascii"))
-
-
-tohex = bytes.hex if sys.version_info >= (3, 5) else b2hex
-"""Python-version-agnostic tohex function. Equivalent to bytes.hex in python 3.5+.
-"""
-
-fromhex = bytes.fromhex if sys.version_info >= (3, 5) else hex2b
-"""Python-version-agnostic fromhex function. Equivalent to bytes.fromhex in python 3.5+.
-"""
+    return "{}{}{}-{}{}-{}{}{}".format(*(rand.randint(0, 9) for i in range(8))).encode(
+        "ascii"
+    )
 
 
 def to_base64_str(bytes_input) -> str:
-    return base64.b64encode(bytes_input).decode('utf-8')
+    return base64.b64encode(bytes_input).decode("utf-8")
 
 
 def base64_to_bytes(str_input) -> bytes:
-    return base64.b64decode(str_input.encode('utf-8'))
+    return base64.b64decode(str_input.encode("utf-8"))
 
 
 def byte_bool(boolv):
-    return b'\x01' if boolv else b'\x00'
+    return b"\x01" if boolv else b"\x00"
 
 
 async def event_wait(event, timeout, loop=None):


### PR DESCRIPTION
We only support python 3.5 and later, remove legacy code
that was unreachable