### PR TITLE
Ensure HTTP 200 status is sent when get_characteristics has no failures

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -51,12 +51,11 @@ from pyhap.loader import Loader
 from pyhap.params import get_srp_context
 from pyhap.state import State
 
+from .const import HAP_SERVER_STATUS
 from .util import callback
 
 logger = logging.getLogger(__name__)
 
-CHAR_STAT_OK = 0
-SERVICE_COMMUNICATION_FAILURE = -70402
 SERVICE_CALLBACK = "callback"
 SERVICE_CHARS = "chars"
 SERVICE_IIDS = "iids"
@@ -682,7 +681,7 @@ class AccessoryDriver:
             rep = {
                 HAP_REPR_AID: aid,
                 HAP_REPR_IID: iid,
-                HAP_REPR_STATUS: SERVICE_COMMUNICATION_FAILURE,
+                HAP_REPR_STATUS: HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             }
 
             try:
@@ -698,7 +697,7 @@ class AccessoryDriver:
 
                 if available:
                     rep[HAP_REPR_VALUE] = char.get_value()
-                    rep[HAP_REPR_STATUS] = CHAR_STAT_OK
+                    rep[HAP_REPR_STATUS] = HAP_SERVER_STATUS.SUCCESS
             except CharacteristicError:
                 logger.error("Error getting value for characteristic %s.", id)
             except Exception:  # pylint: disable=broad-except
@@ -761,10 +760,12 @@ class AccessoryDriver:
                     char.display_name,
                     value,
                 )
-                setter_results[aid][iid] = SERVICE_COMMUNICATION_FAILURE
+                setter_results[aid][
+                    iid
+                ] = HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE
                 had_error = True
             else:
-                setter_results[aid][iid] = CHAR_STAT_OK
+                setter_results[aid][iid] = HAP_SERVER_STATUS.SUCCESS
 
             # For some services we want to send all the char value
             # changes at once.  This resolves an issue where we send
@@ -798,10 +799,10 @@ class AccessoryDriver:
                         client_addr,
                         service_name,
                     )
-                    set_result = SERVICE_COMMUNICATION_FAILURE
+                    set_result = HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE
                     had_error = True
                 else:
-                    set_result = CHAR_STAT_OK
+                    set_result = HAP_SERVER_STATUS.SUCCESS
 
                 for iid in service_data[SERVICE_IIDS]:
                     setter_results[aid][iid] = set_result

--- a/pyhap/const.py
+++ b/pyhap/const.py
@@ -2,8 +2,8 @@
 MAJOR_VERSION = 3
 MINOR_VERSION = 4
 PATCH_VERSION = 0
-__short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
-__version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
+__short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
+__version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5)
 
 # ### Misc ###
@@ -51,26 +51,42 @@ CATEGORY_TARGET_CONTROLLER = 32  # Remote Controller
 
 
 # ### HAP Permissions ###
-HAP_PERMISSION_HIDDEN = 'hd'
-HAP_PERMISSION_NOTIFY = 'ev'
-HAP_PERMISSION_READ = 'pr'
-HAP_PERMISSION_WRITE = 'pw'
-HAP_PERMISSION_WRITE_RESPONSE = 'wr'
+HAP_PERMISSION_HIDDEN = "hd"
+HAP_PERMISSION_NOTIFY = "ev"
+HAP_PERMISSION_READ = "pr"
+HAP_PERMISSION_WRITE = "pw"
+HAP_PERMISSION_WRITE_RESPONSE = "wr"
 
 
 # ### HAP representation ###
-HAP_REPR_ACCS = 'accessories'
-HAP_REPR_AID = 'aid'
-HAP_REPR_CHARS = 'characteristics'
-HAP_REPR_DESC = 'description'
-HAP_REPR_FORMAT = 'format'
-HAP_REPR_IID = 'iid'
-HAP_REPR_MAX_LEN = 'maxLen'
-HAP_REPR_PERM = 'perms'
-HAP_REPR_PRIMARY = 'primary'
-HAP_REPR_SERVICES = 'services'
-HAP_REPR_LINKED = 'linked'
-HAP_REPR_STATUS = 'status'
-HAP_REPR_TYPE = 'type'
-HAP_REPR_VALUE = 'value'
-HAP_REPR_VALID_VALUES = 'valid-values'
+HAP_REPR_ACCS = "accessories"
+HAP_REPR_AID = "aid"
+HAP_REPR_CHARS = "characteristics"
+HAP_REPR_DESC = "description"
+HAP_REPR_FORMAT = "format"
+HAP_REPR_IID = "iid"
+HAP_REPR_MAX_LEN = "maxLen"
+HAP_REPR_PERM = "perms"
+HAP_REPR_PRIMARY = "primary"
+HAP_REPR_SERVICES = "services"
+HAP_REPR_LINKED = "linked"
+HAP_REPR_STATUS = "status"
+HAP_REPR_TYPE = "type"
+HAP_REPR_VALUE = "value"
+HAP_REPR_VALID_VALUES = "valid-values"
+
+
+# Status codes for underlying HAP calls
+class HAP_SERVER_STATUS:
+    SUCCESS = 0
+    INSUFFICIENT_PRIVILEGES = -70401
+    SERVICE_COMMUNICATION_FAILURE = -70402
+    RESOURCE_BUSY = -70403
+    READ_ONLY_CHARACTERISTIC = -70404
+    WRITE_ONLY_CHARACTERISTIC = -70405
+    NOTIFICATION_NOT_SUPPORTED = -70406
+    OUT_OF_RESOURCE = -70407
+    OPERATION_TIMED_OUT = -70408
+    RESOURCE_DOES_NOT_EXIST = -70409
+    INVALID_VALUE_IN_REQUEST = -70410
+    INSUFFICIENT_AUTHORIZATION = -70411

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -9,11 +9,7 @@ import pytest
 
 from pyhap import util
 from pyhap.accessory import STANDALONE_AID, Accessory, Bridge
-from pyhap.accessory_driver import (
-    SERVICE_COMMUNICATION_FAILURE,
-    AccessoryDriver,
-    AccessoryMDNSServiceInfo,
-)
+from pyhap.accessory_driver import AccessoryDriver, AccessoryMDNSServiceInfo
 from pyhap.characteristic import (
     HAP_FORMAT_INT,
     HAP_PERMISSION_READ,
@@ -27,6 +23,7 @@ from pyhap.const import (
     HAP_REPR_IID,
     HAP_REPR_STATUS,
     HAP_REPR_VALUE,
+    HAP_SERVER_STATUS,
 )
 from pyhap.service import Service
 from pyhap.state import State
@@ -303,12 +300,12 @@ def test_service_callbacks_partial_failure(driver):
             {
                 HAP_REPR_AID: acc.aid,
                 HAP_REPR_IID: char_on_iid,
-                HAP_REPR_STATUS: SERVICE_COMMUNICATION_FAILURE,
+                HAP_REPR_STATUS: HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             },
             {
                 HAP_REPR_AID: acc.aid,
                 HAP_REPR_IID: char_brightness_iid,
-                HAP_REPR_STATUS: SERVICE_COMMUNICATION_FAILURE,
+                HAP_REPR_STATUS: HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             },
             {
                 HAP_REPR_AID: acc2.aid,
@@ -396,17 +393,17 @@ def test_mixing_service_char_callbacks_partial_failure(driver):
             {
                 HAP_REPR_AID: acc.aid,
                 HAP_REPR_IID: char_on_iid,
-                HAP_REPR_STATUS: SERVICE_COMMUNICATION_FAILURE,
+                HAP_REPR_STATUS: HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             },
             {
                 HAP_REPR_AID: acc.aid,
                 HAP_REPR_IID: char_brightness_iid,
-                HAP_REPR_STATUS: SERVICE_COMMUNICATION_FAILURE,
+                HAP_REPR_STATUS: HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             },
             {
                 HAP_REPR_AID: acc2.aid,
                 HAP_REPR_IID: char_on2_iid,
-                HAP_REPR_STATUS: SERVICE_COMMUNICATION_FAILURE,
+                HAP_REPR_STATUS: HAP_SERVER_STATUS.SERVICE_COMMUNICATION_FAILURE,
             },
             {
                 HAP_REPR_AID: acc2.aid,

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -4,6 +4,7 @@
 from unittest.mock import patch
 from uuid import UUID
 
+import json
 import pytest
 
 from pyhap import hap_handler
@@ -408,7 +409,10 @@ def test_handle_get_characteristics_encrypted(driver):
     handler.path = "/characteristics?id=1.9"
     handler.handle_get_characteristics()
 
-    assert response.status_code == 207
+    assert response.status_code == 200
+    decoded_response = json.loads(response.body.decode())
+    assert "characteristics" in decoded_response
+    assert "status" not in decoded_response["characteristics"][0]
     assert b'"value": 0' in response.body
 
     with patch.object(acc.iid_manager, "get_obj", side_effect=CharacteristicError):
@@ -418,7 +422,10 @@ def test_handle_get_characteristics_encrypted(driver):
         handler.handle_get_characteristics()
 
     assert response.status_code == 207
-    assert b"-70402" in response.body
+    decoded_response = json.loads(response.body.decode())
+    assert "characteristics" in decoded_response
+    assert "status" in decoded_response["characteristics"][0]
+    assert decoded_response["characteristics"][0]["status"] == -70402
 
 
 def test_invalid_pairing_two(driver):


### PR DESCRIPTION
Previously we always sent a multi-status of 207 even when
there were no failures. HomeKit expects a HTTP 200 response
when there are no failures, and for status to be not
be set in the 100% success state.

This change **drastically** reduces the amount of polling that
the iOS device does because it no longer schedules a retry
based on the unexpected 207 which translates into a meaningful
improvement in battery life.