### PR TITLE
Use zeroconf async registration functions

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -10,4 +10,6 @@ disable=
   too-many-public-methods,
   too-many-return-statements,
   too-many-statements,
-  bad-continuation
+  bad-continuation,
+  unused-argument,
+  consider-using-with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ disable = [
     "too-many-boolean-expressions",
     "unused-argument",
     "wrong-import-order",
+    "unused-argument",
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIRES = [
     'curve25519-donna',
     'ed25519',
     'cryptography',
-    'zeroconf',
+    'zeroconf>=0.30.0',
     'h11'
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,19 @@ def mock_driver():
     yield MockDriver()
 
 
+@pytest.fixture(name="async_zeroconf")
+def async_zc():
+    with patch("pyhap.accessory_driver.AsyncZeroconf") as mock_async_zeroconf:
+        aiozc = mock_async_zeroconf.return_value
+        aiozc.async_register_service = AsyncMock()
+        aiozc.async_update_service = AsyncMock()
+        aiozc.async_unregister_service = AsyncMock()
+        aiozc.async_close = AsyncMock()
+        yield aiozc
+
+
 @pytest.fixture
-def driver():
+def driver(async_zeroconf):
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:
@@ -27,8 +38,6 @@ def driver():
         "pyhap.accessory_driver.HAPServer.async_stop", new_callable=AsyncMock
     ), patch(
         "pyhap.accessory_driver.HAPServer.async_start", new_callable=AsyncMock
-    ), patch(
-        "pyhap.accessory_driver.Zeroconf"
     ), patch(
         "pyhap.accessory_driver.AccessoryDriver.persist"
     ):

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -406,7 +406,7 @@ async def test_bridge_run_stop():
     ), patch(
         "pyhap.accessory_driver.HAPServer.async_start", new_callable=AsyncMock
     ), patch(
-        "pyhap.accessory_driver.Zeroconf"
+        "pyhap.accessory_driver.AsyncZeroconf"
     ), patch(
         "pyhap.accessory_driver.AccessoryDriver.persist"
     ), patch(

--- a/tests/test_hap_server.py
+++ b/tests/test_hap_server.py
@@ -29,7 +29,7 @@ async def test_we_can_start_stop(driver):
 async def test_we_can_connect():
     """Test we can start, connect, and stop."""
     loop = asyncio.get_event_loop()
-    with patch("pyhap.accessory_driver.Zeroconf"), patch(
+    with patch("pyhap.accessory_driver.AsyncZeroconf"), patch(
         "pyhap.accessory_driver.AccessoryDriver.persist"
     ):
         driver = AccessoryDriver(loop=loop)
@@ -59,7 +59,7 @@ async def test_idle_connection_cleanup():
     client_1_addr_info = ("1.2.3.4", 44433)
 
     with patch.object(hap_server, "IDLE_CONNECTION_CHECK_INTERVAL_SECONDS", 0), patch(
-        "pyhap.accessory_driver.Zeroconf"
+        "pyhap.accessory_driver.AsyncZeroconf"
     ), patch("pyhap.accessory_driver.AccessoryDriver.persist"), patch(
         "pyhap.accessory_driver.AccessoryDriver.load"
     ):


### PR DESCRIPTION
Creating an `AccessoryDriver` now accepts an `AsyncZeroconf` instance via `async_zeroconf_instance` instead of a `Zeroconf` instance via `zeroconf_instance`.  No changes are needed if a zeroconf instances was not being passed in.