### PR TITLE
Bump minimum python to 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10.0-alpha.5"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-alpha.5"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ in [the accessories folder](accessories). See how to configure your camera in
 
 ## Installation <a name="Installation"></a>
 
-As of version 2.0.0, HAP-python no longer supports python older than 3.5, because we
+As of version 3.5.1, HAP-python no longer supports python older than 3.6, because we
 are moving to asyncio. If your platform does not have a compatible python out of the
 box, you can install it manually or just use an older version of HAP-python.
 


### PR DESCRIPTION
- 3.5 is EOL and since we need zeroconf 0.32.0+ which requires 3.6
  we now require 3.6