### PR TITLE
Switch to using cryptography ed25519 

### DIFF
--- a/pyhap/state.py
+++ b/pyhap/state.py
@@ -1,5 +1,5 @@
 """Module for `State` class."""
-import ed25519
+from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from pyhap import util
 from pyhap.const import DEFAULT_CONFIG_VERSION, DEFAULT_PORT
@@ -11,8 +11,7 @@ class State:
     That includes all needed for setup of driver and pairing.
     """
 
-    def __init__(self, *, address=None, mac=None,
-                 pincode=None, port=None):
+    def __init__(self, *, address=None, mac=None, pincode=None, port=None):
         """Initialize a new object. Create key pair.
 
         Must be called with keyword arguments.
@@ -26,9 +25,8 @@ class State:
         self.config_version = DEFAULT_CONFIG_VERSION
         self.paired_clients = {}
 
-        sk, vk = ed25519.create_keypair()
-        self.private_key = sk
-        self.public_key = vk
+        self.private_key = ed25519.Ed25519PrivateKey.generate()
+        self.public_key = self.private_key.public_key()
 
     # ### Pairing ###
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 h11
 curve25519-donna
-ed25519
 cryptography
 zeroconf

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,6 +1,5 @@
 base36
 curve25519-donna
-ed25519
 cryptography
 pyqrcode
 h11

--- a/setup.py
+++ b/setup.py
@@ -3,33 +3,26 @@ from setuptools import setup
 
 import pyhap.const as pyhap_const
 
-
-NAME = 'HAP-python'
-DESCRIPTION = 'HomeKit Accessory Protocol implementation in python'
-URL = 'https://github.com/ikalchev/{}'.format(NAME)
-AUTHOR = 'Ivan Kalchev'
+NAME = "HAP-python"
+DESCRIPTION = "HomeKit Accessory Protocol implementation in python"
+URL = "https://github.com/ikalchev/{}".format(NAME)
+AUTHOR = "Ivan Kalchev"
 
 
 PROJECT_URLS = {
-    'Bug Reports': '{}/issues'.format(URL),
-    'Documentation': 'http://hap-python.readthedocs.io/en/latest/',
-    'Source': '{}/tree/master'.format(URL),
+    "Bug Reports": "{}/issues".format(URL),
+    "Documentation": "http://hap-python.readthedocs.io/en/latest/",
+    "Source": "{}/tree/master".format(URL),
 }
 
 
-MIN_PY_VERSION = '.'.join(map(str, pyhap_const.REQUIRED_PYTHON_VER))
+MIN_PY_VERSION = ".".join(map(str, pyhap_const.REQUIRED_PYTHON_VER))
 
-with open('README.md', 'r', encoding='utf-8') as f:
+with open("README.md", "r", encoding="utf-8") as f:
     README = f.read()
 
 
-REQUIRES = [
-    'curve25519-donna',
-    'ed25519',
-    'cryptography',
-    'zeroconf>=0.32.0',
-    'h11'
-]
+REQUIRES = ["curve25519-donna", "cryptography", "zeroconf>=0.32.0", "h11"]
 
 
 setup(
@@ -37,32 +30,32 @@ setup(
     version=pyhap_const.__version__,
     description=DESCRIPTION,
     long_description=README,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url=URL,
-    packages=['pyhap'],
+    packages=["pyhap"],
     include_package_data=True,
     project_urls=PROJECT_URLS,
-    python_requires='>={}'.format(MIN_PY_VERSION),
+    python_requires=">={}".format(MIN_PY_VERSION),
     install_requires=REQUIRES,
-    license='Apache License 2.0',
-    license_file='LICENSE',
+    license="Apache License 2.0",
+    license_file="LICENSE",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: End Users/Desktop',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Home Automation',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: End Users/Desktop",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Home Automation",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     extras_require={
-        'QRCode': ['base36', 'pyqrcode'],
-    }
+        "QRCode": ["base36", "pyqrcode"],
+    },
 )

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -4,9 +4,10 @@ from concurrent.futures import ThreadPoolExecutor
 import tempfile
 from unittest.mock import MagicMock, patch
 from uuid import uuid1
-from zeroconf import InterfaceChoice
 
+from cryptography.hazmat.primitives import serialization
 import pytest
+from zeroconf import InterfaceChoice
 
 from pyhap import util
 from pyhap.accessory import STANDALONE_AID, Accessory, Bridge
@@ -100,7 +101,13 @@ def test_persist_load(async_zeroconf):
             # the new accessory.
             driver = AccessoryDriver(port=51234, persist_file=file.name)
             driver.load()
-    assert driver.state.public_key == pk
+    assert driver.state.public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ) == pk.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
 
 
 def test_persist_cannot_write(async_zeroconf):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,7 @@
 """Test for pyhap.state."""
 from unittest.mock import patch
 
+from cryptography.hazmat.primitives.asymmetric import ed25519
 import pytest
 
 from pyhap.state import State
@@ -16,12 +17,15 @@ def test_setup():
     pin = b"123-45-678"
     port = 11111
 
+    private_key = ed25519.Ed25519PrivateKey.generate()
+
     with patch("pyhap.util.get_local_address") as mock_local_addr, patch(
         "pyhap.util.generate_mac"
     ) as mock_gen_mac, patch("pyhap.util.generate_pincode") as mock_gen_pincode, patch(
         "pyhap.util.generate_setup_id"
     ) as mock_gen_setup_id, patch(
-        "ed25519.create_keypair", return_value=(1, 2)
+        "cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey.generate",
+        return_value=private_key,
     ) as mock_create_keypair:
 
         state = State(address=addr, mac=mac, pincode=pin, port=port)
@@ -48,9 +52,7 @@ def test_pairing():
     """Test if pairing methods work."""
     with patch("pyhap.util.get_local_address"), patch("pyhap.util.generate_mac"), patch(
         "pyhap.util.generate_pincode"
-    ), patch("pyhap.util.generate_setup_id"), patch(
-        "ed25519.create_keypair", return_value=(1, 2)
-    ):
+    ), patch("pyhap.util.generate_setup_id"):
         state = State()
 
     assert not state.paired


### PR DESCRIPTION
- The ed25519 package is no longer recommended by the maintainer https://github.com/warner/python-ed25519#not-recommended-for-new-applications-use-pynacl-instead

- Since we are already using cryptography, it makes sense to use that instead of pynacl

- In testing this was ~2.8x faster which speeds up the transition from cellular to wifi when coming home