### PR TITLE
Reduce event overhead

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-beta.4"]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -283,7 +283,7 @@ class Accessory:
 
     # Driver
 
-    def publish(self, value, sender, sender_client_addr=None):
+    def publish(self, value, sender, sender_client_addr=None, immediate=False):
         """Append AID and IID of the sender and forward it to the driver.
 
         Characteristics call this method to send updates.
@@ -299,7 +299,7 @@ class Accessory:
             HAP_REPR_IID: self.iid_manager.get_iid(sender),
             HAP_REPR_VALUE: value,
         }
-        self.driver.publish(acc_data, sender_client_addr)
+        self.driver.publish(acc_data, sender_client_addr, immediate)
 
 
 class Bridge(Accessory):

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -219,7 +219,9 @@ class Characteristic:
             self.properties[PROP_VALID_VALUES] = valid_values
 
         if self.type_id in ALWAYS_NULL:
-            return None
+            self.value = None
+            return
+
         try:
             self.value = self.to_valid_value(self.value)
         except ValueError:

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -218,6 +218,8 @@ class Characteristic:
         if valid_values:
             self.properties[PROP_VALID_VALUES] = valid_values
 
+        if self.type_id in ALWAYS_NULL:
+            return None
         try:
             self.value = self.to_valid_value(self.value)
         except ValueError:

--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -6,6 +6,9 @@ a temperature measuring or a device status.
 """
 import logging
 
+from uuid import UUID
+
+
 from pyhap.const import (
     HAP_PERMISSION_READ,
     HAP_REPR_DESC,
@@ -78,6 +81,20 @@ PROP_VALID_VALUES = "ValidValues"
 
 PROP_NUMERIC = (PROP_MAX_VALUE, PROP_MIN_VALUE, PROP_MIN_STEP, PROP_UNIT)
 
+CHAR_BUTTON_EVENT = UUID("00000126-0000-1000-8000-0026BB765291")
+CHAR_PROGRAMMABLE_SWITCH_EVENT = UUID("00000073-0000-1000-8000-0026BB765291")
+
+
+IMMEDIATE_NOTIFY = {
+    CHAR_BUTTON_EVENT,  # Button Event
+    CHAR_PROGRAMMABLE_SWITCH_EVENT,  # Programmable Switch Event
+}
+
+# Special case, Programmable Switch Event always have a null value
+ALWAYS_NULL = {
+    CHAR_PROGRAMMABLE_SWITCH_EVENT,  # Programmable Switch Event
+}
+
 
 class CharacteristicError(Exception):
     """Generic exception class for characteristic errors."""
@@ -138,6 +155,9 @@ class Characteristic:
 
     def _get_default_value(self):
         """Return default value for format."""
+        if self.type_id in ALWAYS_NULL:
+            return None
+
         if self.properties.get(PROP_VALID_VALUES):
             return min(self.properties[PROP_VALID_VALUES].values())
 
@@ -224,9 +244,12 @@ class Characteristic:
         """
         logger.debug("set_value: %s to %s", self.display_name, value)
         value = self.to_valid_value(value)
+        changed = self.value != value
         self.value = value
-        if should_notify and self.broker:
+        if changed and should_notify and self.broker:
             self.notify()
+        if self.type_id in ALWAYS_NULL:
+            self.value = None
 
     def client_update_value(self, value, sender_client_addr=None):
         """Called from broker for value change in Home app.
@@ -239,11 +262,15 @@ class Characteristic:
             value,
             sender_client_addr,
         )
+        changed = self.value != value
         self.value = value
-        self.notify(sender_client_addr)
+        if changed:
+            self.notify(sender_client_addr)
         if self.setter_callback:
             # pylint: disable=not-callable
             self.setter_callback(value)
+        if self.type_id in ALWAYS_NULL:
+            self.value = None
 
     def notify(self, sender_client_addr=None):
         """Notify clients about a value change. Sends the value.
@@ -251,7 +278,8 @@ class Characteristic:
         .. seealso:: accessory.publish
         .. seealso:: accessory_driver.publish
         """
-        self.broker.publish(self.value, self, sender_client_addr)
+        immediate = self.type_id in IMMEDIATE_NOTIFY
+        self.broker.publish(self.value, self, sender_client_addr, immediate)
 
     # pylint: disable=invalid-name
     def to_HAP(self):

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -98,7 +98,6 @@ class HAPServerProtocol(asyncio.Protocol):
 
     def queue_event(self, data: dict, immediate: bool) -> None:
         """Queue an event for sending."""
-        logger.debug("Appending %s to event queue: %s", data, self._event_queue)
         self._event_queue.append(data)
         if immediate:
             self.loop.call_soon(self._send_events)

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -4,16 +4,17 @@ The HAPServerProtocol is a protocol implementation that manages the "TLS" of the
 """
 import asyncio
 import logging
-from pyhap.accessory import get_topic
-from pyhap.const import HAP_REPR_AID, HAP_REPR_IID
 import time
 
 from cryptography.exceptions import InvalidTag
 import h11
 
+from pyhap.accessory import get_topic
+from pyhap.const import HAP_REPR_AID, HAP_REPR_IID
+
 from .hap_crypto import HAPCrypto
-from .hap_handler import HAPResponse, HAPServerHandler
 from .hap_event import create_hap_event
+from .hap_handler import HAPResponse, HAPServerHandler
 
 logger = logging.getLogger(__name__)
 

--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -70,7 +70,7 @@ class HAPServer:
         self.server.close()
         self.connections.clear()
 
-    def push_event(self, data, client_addr):
+    def push_event(self, data, client_addr, immediate=False):
         """Queue an event to the current connection with the provided data.
 
         :param data: The charateristic changes
@@ -86,5 +86,5 @@ class HAPServer:
         if hap_server_protocol is None:
             logger.debug("No socket for %s", client_addr)
             return False
-        hap_server_protocol.queue_event(data)
+        hap_server_protocol.queue_event(data, immediate)
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ class MockDriver:
     def __init__(self):
         self.loader = Loader()
 
-    def publish(self, data, client_addr=None):
+    def publish(self, data, client_addr=None, immediate=False):
         pass
 
     def add_job(self, target, *args):  # pylint: disable=no-self-use

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -473,6 +473,6 @@ def test_acc_with_(mock_driver):
         valid_values={"SinglePress": 0},
     )
     char_doorbell_detected_switch.client_update_value(0)
-    char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None
+    assert char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None
     char_doorbell_detected_switch.client_update_value(None)
-    char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None
+    assert char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -12,6 +12,7 @@ from pyhap.const import (
     CATEGORY_CAMERA,
     CATEGORY_TARGET_CONTROLLER,
     CATEGORY_TELEVISION,
+    HAP_REPR_VALUE,
     STANDALONE_AID,
 )
 from pyhap.service import Service
@@ -460,3 +461,18 @@ async def test_bridge_run_stop():
         await bridge.stop()
     assert acc.stopped is True
     assert acc2.stopped is True
+
+
+def test_acc_with_(mock_driver):
+    """Test ProgrammableSwitchEvent is always None."""
+    acc = Accessory(mock_driver, "Test Accessory")
+    serv_stateless_switch = acc.add_preload_service("StatelessProgrammableSwitch")
+    char_doorbell_detected_switch = serv_stateless_switch.configure_char(
+        "ProgrammableSwitchEvent",
+        value=0,
+        valid_values={"SinglePress": 0},
+    )
+    char_doorbell_detected_switch.client_update_value(0)
+    char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None
+    char_doorbell_detected_switch.client_update_value(None)
+    char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -555,7 +555,7 @@ def test_send_events(driver):
     class HapServerMock:
         pushed_events = set()
 
-        def push_event(self, bytedata, client_addr):
+        def push_event(self, bytedata, client_addr, immediate):
             self.pushed_events.add((bytedata, client_addr))
             if client_addr == "client2":
                 return False
@@ -567,7 +567,7 @@ def test_send_events(driver):
     driver.http_server = HapServerMock()
     driver.loop = LoopMock()
     driver.topics = {"mocktopic": {"client1", "client2", "client3"}}
-    driver.async_send_event("mocktopic", "bytedata", "client1")
+    driver.async_send_event("mocktopic", "bytedata", "client1", True)
 
     # Only client2 and client3 get the event when client1 sent it
     assert driver.http_server.get_pushed_events() == {

--- a/tests/test_hap_server.py
+++ b/tests/test_hap_server.py
@@ -99,11 +99,24 @@ async def test_push_event(driver):
     await asyncio.sleep(0)
     server.connections[addr_info] = hap_server_protocol
 
-    assert server.push_event({"aid": 1}, addr_info) is True
-    assert server.push_event({"aid": 2}, addr_info) is True
-    assert server.push_event({"aid": 3}, addr_info) is True
+    assert server.push_event({"aid": 1}, addr_info, True) is True
+    assert server.push_event({"aid": 2}, addr_info, True) is True
+    assert server.push_event({"aid": 3}, addr_info, True) is True
 
     await asyncio.sleep(0)
+    assert hap_events == [
+        b"EVENT/1.0 200 OK\r\nContent-Type: application/hap+json\r\nContent-Length: 51\r\n\r\n"
+        b'{"characteristics":[{"aid":1},{"aid":2},{"aid":3}]}'
+    ]
+
+    hap_events = []
+    assert server.push_event({"aid": 1}, addr_info, False) is True
+    assert server.push_event({"aid": 2}, addr_info, False) is True
+    assert server.push_event({"aid": 3}, addr_info, False) is True
+
+    await asyncio.sleep(0)
+    assert hap_events == []
+    await asyncio.sleep(0.55)
     assert hap_events == [
         b"EVENT/1.0 200 OK\r\nContent-Type: application/hap+json\r\nContent-Length: 51\r\n\r\n"
         b'{"characteristics":[{"aid":1},{"aid":2},{"aid":3}]}'

--- a/tests/test_hap_server.py
+++ b/tests/test_hap_server.py
@@ -119,7 +119,8 @@ async def test_push_event(driver):
     await asyncio.sleep(0)
     assert hap_events == [
         b"EVENT/1.0 200 OK\r\nContent-Type: application/hap+json\r\nContent-Length: 120\r\n\r\n"
-        b'{"characteristics":[{"aid":1,"iid":33,"value":false},{"aid":2,"iid":33,"value":false},{"aid":3,"iid":33,"value":false}]}'
+        b'{"characteristics":[{"aid":1,"iid":33,"value":false},'
+        b'{"aid":2,"iid":33,"value":false},{"aid":3,"iid":33,"value":false}]}'
     ]
 
     hap_events = []


### PR DESCRIPTION
- Only send an event if the characteristic has changed value

- Coalesce events that happen within the same 500ms window except
  for Button Events and Programmable Switch Events which are delivered
  as soon as possible

- Ensure Programmable Switch Events always serialize to null
  to handle the special case in the spec (except for events).

- MAJOR: Sending an event after the client has been unsubscribed may cause
  iOS to disconnect the accessory and reconnect which makes everything
  go unavailable while the connection is set back up. We now check to
  make sure that the client still wants the event right before sending it
  to avoid the disconnect.

Fixes #359 Fixes #364