### PR TITLE
Decrease snapshot timeout to avoid being disconnected

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-alpha.5"]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -27,7 +27,11 @@ from pyhap.util import long_to_bytes
 from .hap_crypto import hap_hkdf, pad_tls_nonce
 from .util import to_hap_json
 
-SNAPSHOT_TIMEOUT = 10
+
+# iOS will terminate the connection if it does not respond within
+# 10 seconds, so we only allow 9 seconds to avoid this.
+RESPONSE_TIMEOUT = 9
+
 
 logger = logging.getLogger(__name__)
 
@@ -737,7 +741,7 @@ class HAPServerHandler:
                 'does not define a "get_snapshot" or "async_get_snapshot" method'
             )
 
-        task = asyncio.ensure_future(asyncio.wait_for(coro, SNAPSHOT_TIMEOUT))
+        task = asyncio.ensure_future(asyncio.wait_for(coro, RESPONSE_TIMEOUT))
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", "image/jpeg")
         self.response.task = task

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -113,7 +113,6 @@ class HAPServerProtocol(asyncio.Protocol):
             + self.conn.send(h11.Data(data=response.body))
             + self.conn.send(h11.EndOfMessage())
         )
-        self.transport.resume_reading()
 
     def finish_and_close(self):
         """Cleanly finish and close the connection."""
@@ -194,7 +193,6 @@ class HAPServerProtocol(asyncio.Protocol):
             return True
 
         if isinstance(event, h11.EndOfMessage):
-            self.transport.pause_reading()
             time_before = time.time()
             response = self.handler.dispatch(self.request, bytes(self.request_body))
             logging.debug(

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -195,7 +195,13 @@ class HAPServerProtocol(asyncio.Protocol):
 
         if isinstance(event, h11.EndOfMessage):
             self.transport.pause_reading()
+            time_before = time.time()
             response = self.handler.dispatch(self.request, bytes(self.request_body))
+            logging.debug(
+                "Handling request: %s took %s seconds",
+                self.request,
+                time.time() - time_before,
+            )
             self._process_response(response)
             self.request = None
             self.request_body = None

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -193,13 +193,7 @@ class HAPServerProtocol(asyncio.Protocol):
             return True
 
         if isinstance(event, h11.EndOfMessage):
-            time_before = time.time()
             response = self.handler.dispatch(self.request, bytes(self.request_body))
-            logging.debug(
-                "Handling request: %s took %s seconds",
-                self.request,
-                time.time() - time_before,
-            )
             self._process_response(response)
             self.request = None
             self.request_body = None


### PR DESCRIPTION
- iOS will terminate the connection if it does not respond within
  10 seconds, so we only allow 9 seconds to avoid this.

- We no longer need to pause reading when taking a snapshot
  as we have a working timeout