### PR TITLE
Avoid writing delayed camera snapshots when the connection is closed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-alpha.5"]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -88,6 +88,7 @@ class HAPServerProtocol(asyncio.Protocol):
         """Remove the connection and close the transport."""
         if self.peername in self.connections:
             del self.connections[self.peername]
+        self.transport.write_eof()
         self.transport.close()
 
     def queue_event(self, data: dict) -> None:
@@ -233,6 +234,12 @@ class HAPServerProtocol(asyncio.Protocol):
                 "%s: exception during delayed response", self.peername, exc_info=ex
             )
             response = self.handler.generic_failure_response()
+        if self.transport.is_closing():
+            logger.debug(
+                "%s: delayed response not sent as the transport as closed.",
+                self.peername,
+            )
+            return
         self.send_response(response)
 
     def _handle_invalid_conn_state(self, message):

--- a/tests/test_hap_protocol.py
+++ b/tests/test_hap_protocol.py
@@ -363,10 +363,45 @@ def test_http_11_keep_alive(driver):
     hap_proto.close()
 
 
+@pytest.mark.asyncio
+async def test_camera_snapshot_connection_closed(driver):
+    """Test camera snapshot when the other side closes the connection."""
+    loop = MagicMock()
+    transport = MagicMock()
+    transport.is_closing = Mock(return_value=True)
+    connections = {}
+
+    async def _async_get_snapshot(*_):
+        return b"fakesnap"
+
+    acc = Accessory(driver, "TestAcc")
+    acc.async_get_snapshot = _async_get_snapshot
+    driver.add_accessory(acc)
+
+    hap_proto = hap_protocol.HAPServerProtocol(loop, connections, driver)
+    hap_proto.connection_made(transport)
+
+    hap_proto.hap_crypto = MockHAPCrypto()
+    hap_proto.handler.is_encrypted = True
+
+    with patch.object(hap_proto.transport, "write") as writer:
+        hap_proto.data_received(
+            b'POST /resource HTTP/1.1\r\nHost: HASS\\032Bridge\\032BROZ\\0323BF435._hap._tcp.local\r\nContent-Length: 79\r\nContent-Type: application/hap+json\r\n\r\n{"image-height":360,"resource-type":"image","image-width":640,"aid":1411620844}'  # pylint: disable=line-too-long
+        )
+        hap_proto.close()
+        await hap_proto.response.task
+        await asyncio.sleep(0)
+
+    assert writer.call_args_list == []
+
+    hap_proto.close()
+
+
 def test_camera_snapshot_without_snapshot_support(driver):
     """Test camera snapshot fails if there is not support for it."""
     loop = MagicMock()
     transport = MagicMock()
+    transport.is_closing = Mock(return_value=False)
     connections = {}
 
     acc = Accessory(driver, "TestAcc")
@@ -392,6 +427,7 @@ async def test_camera_snapshot_works_sync(driver):
     """Test camera snapshot works if there is support for it."""
     loop = MagicMock()
     transport = MagicMock()
+    transport.is_closing = Mock(return_value=False)
     connections = {}
 
     def _get_snapshot(*_):
@@ -424,6 +460,7 @@ async def test_camera_snapshot_works_async(driver):
     """Test camera snapshot works if there is support for it."""
     loop = MagicMock()
     transport = MagicMock()
+    transport.is_closing = Mock(return_value=False)
     connections = {}
 
     async def _async_get_snapshot(*_):
@@ -455,6 +492,7 @@ def test_upgrade_to_encrypted(driver):
     """Test we switch to encrypted wen we get a shared_key."""
     loop = MagicMock()
     transport = MagicMock()
+    transport.is_closing = Mock(return_value=False)
     connections = {}
 
     acc = Accessory(driver, "TestAcc")
@@ -525,6 +563,7 @@ async def test_camera_snapshot_throws_an_exception(driver):
     """Test camera snapshot that throws an exception."""
     loop = MagicMock()
     transport = MagicMock()
+    transport.is_closing = Mock(return_value=False)
     connections = {}
 
     async def _async_get_snapshot(*_):
@@ -560,6 +599,7 @@ async def test_camera_snapshot_times_out(driver):
     """Test camera snapshot times out."""
     loop = MagicMock()
     transport = MagicMock()
+    transport.is_closing = Mock(return_value=False)
     connections = {}
 
     def _get_snapshot(*_):


### PR DESCRIPTION
- If the remote end closed the connection, we would still try to write
  the camera snapshot if it came back after the connection was closed.