### PR TITLE
Add Accessory Start Method

### DIFF
--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -293,6 +293,12 @@ class Accessory:
         Can be overridden with a normal or async method.
         """
 
+    async def start(self):
+        """Called to do any startup an accessory requires
+
+        Can be overridden with a normal or async method.
+        """
+
     async def stop(self):
         """Called when the Accessory should stop what is doing and clean up any resources.
 

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -230,6 +230,7 @@ class AccessoryDriver:
             self.executor = None
 
         self.loop = loop
+        asyncio.set_event_loop(loop)
 
         self.accessory = None
         self.advertiser = async_zeroconf_instance
@@ -337,6 +338,8 @@ class AccessoryDriver:
         await self.advertiser.async_register_service(
             self.mdns_service_info, cooperating_responders=True
         )
+
+        await self.accessory.start()
 
         # Print accessory setup message
         if not self.state.paired:

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -339,7 +339,8 @@ class AccessoryDriver:
             self.mdns_service_info, cooperating_responders=True
         )
 
-        await self.accessory.start()
+        # Run the accessory start method
+        await self.async_add_job(self.accessory.start())
 
         # Print accessory setup message
         if not self.state.paired:


### PR DESCRIPTION
Adds support for a `start()` method/coroutine on accessories.

I wanted to do some async startup for an accessory, and found that a start method was pretty clean.