### PR TITLE
Increment the config version when the accessories change

### DIFF
--- a/pyhap/const.py
+++ b/pyhap/const.py
@@ -12,7 +12,7 @@ BASE_UUID = "-0000-1000-8000-0026BB765291"
 STANDALONE_AID = 1  # Standalone accessory ID (i.e. not bridged)
 
 # ### Default values ###
-DEFAULT_CONFIG_VERSION = 2
+DEFAULT_CONFIG_VERSION = 1
 DEFAULT_PORT = 51827
 
 # ### Configuration version ###

--- a/pyhap/encoder.py
+++ b/pyhap/encoder.py
@@ -34,6 +34,7 @@ class AccessoryEncoder:
         - UUID and public key of all paired clients.
         - MAC address.
         - Config version - ok, this is debatable, but it retains the consistency.
+        - Accessories Hash
 
     The default implementation persists the above properties.
 
@@ -52,6 +53,7 @@ class AccessoryEncoder:
             - Public and private key.
             - UUID and public key of paired clients.
             - Config version.
+            - Accessories Hash
         """
         paired_clients = {
             str(client): bytes.hex(key) for client, key in state.paired_clients.items()
@@ -64,6 +66,7 @@ class AccessoryEncoder:
             "config_version": state.config_version,
             "paired_clients": paired_clients,
             "client_properties": client_properties,
+            "accessories_hash": state.accessories_hash,
             "private_key": bytes.hex(
                 state.private_key.private_bytes(
                     encoding=serialization.Encoding.Raw,
@@ -88,6 +91,7 @@ class AccessoryEncoder:
         """
         loaded = json.load(fp)
         state.mac = loaded["mac"]
+        state.accessories_hash = loaded.get("accessories_hash")
         state.config_version = loaded["config_version"]
         if "client_properties" in loaded:
             state.client_properties = {

--- a/pyhap/loader.py
+++ b/pyhap/loader.py
@@ -33,7 +33,7 @@ class Loader:
     @staticmethod
     def _read_file(path):
         """Read file and return a dict."""
-        with open(path, "r") as file:
+        with open(path, "r", encoding="utf8") as file:
             return json.load(file)
 
     def get_char(self, name):

--- a/pyhap/state.py
+++ b/pyhap/state.py
@@ -2,7 +2,12 @@
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from pyhap import util
-from pyhap.const import CLIENT_PROP_PERMS, DEFAULT_CONFIG_VERSION, DEFAULT_PORT
+from pyhap.const import (
+    CLIENT_PROP_PERMS,
+    DEFAULT_CONFIG_VERSION,
+    DEFAULT_PORT,
+    MAX_CONFIG_VERSION,
+)
 
 ADMIN_BIT = 0x01
 
@@ -30,6 +35,7 @@ class State:
 
         self.private_key = ed25519.Ed25519PrivateKey.generate()
         self.public_key = self.private_key.public_key()
+        self.accessories_hash = None
 
     # ### Pairing ###
     @property
@@ -69,3 +75,17 @@ class State:
         if not any(self.is_admin(client_uuid) for client_uuid in self.paired_clients):
             self.paired_clients.clear()
             self.client_properties.clear()
+
+    def set_accessories_hash(self, accessories_hash):
+        """Set the accessories hash and increment the config version if needed."""
+        if self.accessories_hash == accessories_hash:
+            return False
+        self.accessories_hash = accessories_hash
+        self.increment_config_version()
+        return True
+
+    def increment_config_version(self):
+        """Increment the config version."""
+        self.config_version += 1
+        if self.config_version > MAX_CONFIG_VERSION:
+            self.config_version = 1

--- a/pyhap/util.py
+++ b/pyhap/util.py
@@ -61,7 +61,7 @@ def long_to_bytes(n):
     :return: ``long int`` in ``bytes`` format.
     :rtype: bytes
     """
-    byteList = list()
+    byteList = []
     x = 0
     off = 0
     while x != n:
@@ -158,3 +158,8 @@ def hap_type_to_uuid(hap_type):
 def to_hap_json(dump_obj):
     """Convert an object to HAP json."""
     return json.dumps(dump_obj, separators=(",", ":")).encode("utf-8")
+
+
+def to_sorted_hap_json(dump_obj):
+    """Convert an object to sorted HAP json."""
+    return json.dumps(dump_obj, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -669,6 +669,7 @@ async def test_start_stop_sync_acc(async_zeroconf):
         driver.add_accessory(acc)
         driver.start_service()
         await run_event.wait()
+        assert driver.state.config_version == 2
         assert not driver.loop.is_closed()
         await driver.async_stop()
         assert not driver.loop.is_closed()
@@ -704,7 +705,35 @@ async def test_start_stop_async_acc(async_zeroconf):
         driver.start_service()
         await asyncio.sleep(0)
         await run_event.wait()
+        assert driver.state.config_version == 2
         assert not driver.loop.is_closed()
+        await driver.async_stop()
+        assert not driver.loop.is_closed()
+
+        run_event.clear()
+        driver.start_service()
+        await asyncio.sleep(0)
+        await run_event.wait()
+        assert driver.state.config_version == 2
+        await driver.async_stop()
+        assert not driver.loop.is_closed()
+        acc.add_preload_service("GarageDoorOpener")
+
+        # Adding a new service should increment the config version
+        run_event.clear()
+        driver.start_service()
+        await asyncio.sleep(0)
+        await run_event.wait()
+        assert driver.state.config_version == 3
+        await driver.async_stop()
+        assert not driver.loop.is_closed()
+
+        # But only once
+        run_event.clear()
+        driver.start_service()
+        await asyncio.sleep(0)
+        await run_event.wait()
+        assert driver.state.config_version == 3
         await driver.async_stop()
         assert not driver.loop.is_closed()
 
@@ -816,7 +845,7 @@ def test_mdns_service_info(driver):
         "md": "Test Accessory",
         "pv": "1.1",
         "id": "00:00:00:00:00:00",
-        "c#": "2",
+        "c#": "1",
         "s#": "1",
         "ff": "0",
         "ci": "1",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -46,7 +46,7 @@ def test_setup():
         assert mock_gen_mac.called
         assert mock_gen_pincode.called
         assert state.port == 51827
-        assert state.config_version == 2
+        assert state.config_version == 1
 
 
 def test_pairing_remove_last_admin():


### PR DESCRIPTION
- We now hash a sorted version of `/accessories` at start
  so we can tell when it changes and increment the config version

- Incrementing the config version tells iOS that it needs to
  evict its cache of /accessories to prevent invalid state

- Fixes accessories showing non-responsive or missing services
  because their services have changed and iOS is unaware because its
  using the old version of `/accessories`