### PR TITLE
Allow passing the zeroconf server name when creating the AccessoryDriver

### DIFF
--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -854,6 +854,35 @@ def test_mdns_service_info(driver):
     }
 
 
+def test_mdns_service_info_with_specified_server(driver):
+    """Test accessory mdns advert when the server is specified."""
+    acc = Accessory(driver, "Test Accessory")
+    driver.add_accessory(acc)
+    addr = "172.0.0.1"
+    mac = "00:00:00:00:00:00"
+    pin = b"123-45-678"
+    port = 11111
+    state = State(address=addr, mac=mac, pincode=pin, port=port)
+    state.setup_id = "abc"
+    mdns_info = AccessoryMDNSServiceInfo(acc, state, "hap1.local.")
+    assert mdns_info.type == "_hap._tcp.local."
+    assert mdns_info.name == "Test Accessory 000000._hap._tcp.local."
+    assert mdns_info.server == "hap1.local."
+    assert mdns_info.port == port
+    assert mdns_info.addresses == [b"\xac\x00\x00\x01"]
+    assert mdns_info.properties == {
+        "md": "Test Accessory",
+        "pv": "1.1",
+        "id": "00:00:00:00:00:00",
+        "c#": "1",
+        "s#": "1",
+        "ff": "0",
+        "ci": "1",
+        "sf": "1",
+        "sh": "+KjpzQ==",
+    }
+
+
 @pytest.mark.parametrize(
     "accessory_name, mdns_name, mdns_server",
     [


### PR DESCRIPTION
- When there are multiple bridges running with the same address, each
  A record has to be kept fresh. By using the same server for all the bridges
  we avoid a case where the amount of broadcast traffic exceeds the limit
  and the bridges become unavailable