### PR TITLE
Bump zeroconf to 0.36.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r", encoding="utf-8") as f:
     README = f.read()
 
 
-REQUIRES = ["cryptography", "zeroconf>=0.32.0", "h11"]
+REQUIRES = ["cryptography", "zeroconf>=0.36.2", "h11"]
 
 
 setup(


### PR DESCRIPTION
- Fixes a case where a HomeKit bridge can take a while to update
  because it is waiting to see if an AAAA (IPv6) address is available

- Changes: https://github.com/jstasiak/python-zeroconf/compare/0.32.0...0.36.2