### PR TITLE
Handle invalid formats from clients

### DIFF
--- a/pyhap/characteristic.py
+++ b/pyhap/characteristic.py
@@ -281,10 +281,14 @@ class Characteristic:
 
         Change self.value to value and call callback.
         """
+        original_value = value
+        if self.type_id not in ALWAYS_NULL or original_value is not None:
+            value = self.to_valid_value(value)
         logger.debug(
-            "client_update_value: %s to %s from client: %s",
+            "client_update_value: %s to %s (original: %s) from client: %s",
             self.display_name,
             value,
+            original_value,
             sender_client_addr,
         )
         changed = self.value != value

--- a/tests/test_accessory.py
+++ b/tests/test_accessory.py
@@ -550,3 +550,13 @@ def test_acc_with_(mock_driver):
     assert char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None
     char_doorbell_detected_switch.client_update_value(None)
     assert char_doorbell_detected_switch.to_HAP()[HAP_REPR_VALUE] is None
+
+
+def test_client_sends_invalid_value(mock_driver):
+    """Test cleaning up invalid client value."""
+    acc = Accessory(mock_driver, "Test Accessory")
+    serv_switch = acc.add_preload_service("Switch")
+    char_on = serv_switch.configure_char("On", value=False)
+    # Client sends 1, but it should be True
+    char_on.client_update_value(1)
+    assert char_on.to_HAP()[HAP_REPR_VALUE] is True


### PR DESCRIPTION
Some clients mix and match True for 1 and False for 0
when setting state. We now cleanup the values from
the client to ensure internal state is always valid.