### PR TITLE
Add source button to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ release = '.'.join(map(str, __version__))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc', 'sphinx.ext.viewcode'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This PR adds a `source` button to each function/class signature on the docs website. People can directly view the code on the docs website without switching to the repository, making source code viewing easier.