### PR TITLE
README.md has nonfunctional API example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,52 +61,69 @@ will take care of advertising it on the local network, setting a HAP server and
 running the Accessory. Take a look at [main.py](main.py) for a quick start on that.
 
 ```python
-from pyhap.accessory import Accessory, Category
+"""An example of how to setup and start an Accessory.
+This is:
+1. Create the Accessory object you want.
+2. Add it to an AccessoryDriver, which will advertise it on the local network,
+    setup a server to answer client queries, etc.
+"""
+import logging
+import signal
+import random
+
+from pyhap.accessory import Accessory, Bridge
+from pyhap.accessory_driver import AccessoryDriver
 import pyhap.loader as loader
+from pyhap import camera
+from pyhap.const import CATEGORY_SENSOR
+
+logging.basicConfig(level=logging.INFO, format="[%(module)s] %(message)s")
+
 
 class TemperatureSensor(Accessory):
-    """Implementation of a mock temperature sensor accessory."""
+    """Fake Temperature sensor, measuring every 3 seconds."""
 
-    category = Category.SENSOR  # This is for the icon in the iOS Home app.
+    category = CATEGORY_SENSOR
 
     def __init__(self, *args, **kwargs):
-        """Here, we just store a reference to the current temperature characteristic and
-        add a method that will be executed every time its value changes.
-        """
-        # If overriding this method, be sure to call the super's implementation first.
         super().__init__(*args, **kwargs)
 
-        # Add the services that this Accessory will support with add_preload_service here
-        temp_service = self.add_preload_service('TemperatureSensor')
-        self.temp_char = temp_service.get_characteristic('CurrentTemperature')
+        serv_temp = self.add_preload_service('TemperatureSensor')
+        self.char_temp = serv_temp.configure_char('CurrentTemperature')
 
-        # Having a callback is optional, but you can use it to add functionality.
-        self.temp_char.setter_callback = self.temperature_changed
+    @Accessory.run_at_interval(3)
+    async def run(self):
+        self.char_temp.set_value(random.randint(18, 26))
 
-    def temperature_changed(self, value):
-        """This will be called every time the value of the CurrentTemperature
-        is changed. Use setter_callbacks to react to user actions, e.g. setting the
-        lights On could fire some GPIO code to turn on a LED (see pyhap/accessories/LightBulb.py).
-        """
-        print('Temperature changed to: ', value)
 
-    @Acessory.run_at_interval(3)  # Run this method every 3 seconds
-    # The `run` method can be `async` as well
-    def run(self):
-        """We override this method to implement what the accessory will do when it is
-        started.
+def get_bridge(driver):
+    """Call this method to get a Bridge instead of a standalone accessory."""
+    bridge = Bridge(driver, 'Bridge')
+    temp_sensor = TemperatureSensor(driver, 'Sensor 2')
+    temp_sensor2 = TemperatureSensor(driver, 'Sensor 1')
+    bridge.add_accessory(temp_sensor)
+    bridge.add_accessory(temp_sensor2)
 
-        We set the current temperature to a random number. The decorator runs this method
-        every 3 seconds.
-        """
-        self.temp_char.set_value(random.randint(18, 26))
+    return bridge
 
-    # The `stop` method can be `async` as well
-    def stop(self):
-        """We override this method to clean up any resources or perform final actions, as
-        this is called by the AccessoryDriver when the Accessory is being stopped.
-        """
-        print('Stopping accessory.')
+
+def get_accessory(driver):
+    """Call this method to get a standalone Accessory."""
+    return TemperatureSensor(driver, 'MyTempSensor')
+
+
+# Start the accessory on port 51826
+driver = AccessoryDriver(port=51826)
+
+# Change `get_accessory` to `get_bridge` if you want to run a Bridge.
+driver.add_accessory(accessory=get_accessory(driver))
+
+# We want SIGTERM (terminate) to be handled by the driver itself,
+# so that it can gracefully stop the accessory, server and advertising.
+signal.signal(signal.SIGTERM, driver.signal_handler)
+
+# Start it!
+driver.start()
 ```
 
 ## Service Callbacks


### PR DESCRIPTION
I executed the API example code provided under the section "API".
This returned with an error for the import of the Category class.

After some digging I came to the conclusion that the example uses deprecated code.
Additionally it includes some misspelling (Acessory instead of Accessory).

I'm under the impression that the example is supposed to be identical to the contents of main.py
This pull request exchanges the code example with the contents of main.py