### PR TITLE
Retain the original format of the UUID

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -25,8 +25,8 @@ import re
 import socket
 import sys
 import tempfile
-import time
 import threading
+import time
 
 from zeroconf import ServiceInfo
 from zeroconf.asyncio import AsyncZeroconf
@@ -41,9 +41,9 @@ from pyhap.const import (
     HAP_REPR_AID,
     HAP_REPR_CHARS,
     HAP_REPR_IID,
-    HAP_REPR_TTL,
     HAP_REPR_PID,
     HAP_REPR_STATUS,
+    HAP_REPR_TTL,
     HAP_REPR_VALUE,
     STANDALONE_AID,
 )
@@ -643,7 +643,9 @@ class AccessoryDriver:
             ) as file_handle:
                 tmp_filename = file_handle.name
                 self.encoder.persist(file_handle, self.state)
-            if os.name == 'nt':  # Or `[WinError 5] Access Denied` will be raised on Windows
+            if (
+                os.name == "nt"
+            ):  # Or `[WinError 5] Access Denied` will be raised on Windows
                 os.chmod(tmp_filename, 0o644)
                 os.chmod(self.persist_file, 0o644)
             os.replace(tmp_filename, self.persist_file)
@@ -663,13 +665,18 @@ class AccessoryDriver:
             self.encoder.load_into(file_handle, self.state)
 
     @callback
-    def pair(self, client_uuid, client_public, client_permissions):
+    def pair(
+        self,
+        client_username_bytes: bytes,
+        client_public: bytes,
+        client_permissions: bytes,
+    ) -> bool:
         """Called when a client has paired with the accessory.
 
         Persist the new accessory state.
 
-        :param client_uuid: The client uuid.
-        :type client_uuid: uuid.UUID
+        :param client_username_bytes: The client username bytes.
+        :type client_username_bytes: bytes
 
         :param client_public: The client's public key.
         :type client_public: bytes
@@ -681,9 +688,13 @@ class AccessoryDriver:
         :rtype: bool
         """
         logger.info(
-            "Paired with %s with permissions %s.", client_uuid, client_permissions
+            "Paired with %s with permissions %s.",
+            client_username_bytes,
+            client_permissions,
         )
-        self.state.add_paired_client(client_uuid, client_public, client_permissions)
+        self.state.add_paired_client(
+            client_username_bytes, client_public, client_permissions
+        )
         self.async_persist()
         return True
 

--- a/pyhap/encoder.py
+++ b/pyhap/encoder.py
@@ -10,6 +10,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from .const import CLIENT_PROP_PERMS
+from .state import State
 
 
 class AccessoryEncoder:
@@ -45,7 +46,7 @@ class AccessoryEncoder:
     """
 
     @staticmethod
-    def persist(fp, state):
+    def persist(fp, state: State):
         """Persist the state of the given Accessory to the given file object.
 
         Persists:
@@ -61,12 +62,16 @@ class AccessoryEncoder:
         client_properties = {
             str(client): props for client, props in state.client_properties.items()
         }
+        client_uuid_to_bytes = {
+            str(client): bytes.hex(key) for client, key in state.uuid_to_binary.items()
+        }
         config_state = {
             "mac": state.mac,
             "config_version": state.config_version,
             "paired_clients": paired_clients,
             "client_properties": client_properties,
             "accessories_hash": state.accessories_hash,
+            "client_uuid_to_bytes": client_uuid_to_bytes,
             "private_key": bytes.hex(
                 state.private_key.private_bytes(
                     encoding=serialization.Encoding.Raw,
@@ -84,7 +89,7 @@ class AccessoryEncoder:
         json.dump(config_state, fp)
 
     @staticmethod
-    def load_into(fp, state):
+    def load_into(fp, state: State) -> None:
         """Load the accessory state from the given file object into the given Accessory.
 
         @see: AccessoryEncoder.persist
@@ -115,3 +120,7 @@ class AccessoryEncoder:
         state.public_key = ed25519.Ed25519PublicKey.from_public_bytes(
             bytes.fromhex(loaded["public_key"])
         )
+        state.uuid_to_binary = {
+            uuid.UUID(client): bytes.fromhex(key)
+            for client, key in loaded.get("client_uuid_to_bytes", {}).items()
+        }

--- a/pyhap/encoder.py
+++ b/pyhap/encoder.py
@@ -63,7 +63,7 @@ class AccessoryEncoder:
             str(client): props for client, props in state.client_properties.items()
         }
         client_uuid_to_bytes = {
-            str(client): bytes.hex(key) for client, key in state.uuid_to_binary.items()
+            str(client): bytes.hex(key) for client, key in state.uuid_to_bytes.items()
         }
         config_state = {
             "mac": state.mac,
@@ -120,7 +120,7 @@ class AccessoryEncoder:
         state.public_key = ed25519.Ed25519PublicKey.from_public_bytes(
             bytes.fromhex(loaded["public_key"])
         )
-        state.uuid_to_binary = {
+        state.uuid_to_bytes = {
             uuid.UUID(client): bytes.fromhex(key)
             for client, key in loaded.get("client_uuid_to_bytes", {}).items()
         }

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -193,18 +193,18 @@ class HAPServerHandler:
         response code.
         Does not add Server or Date
         """
-        assert self.response is not None
+        assert self.response is not None  # nosec
         self.response.status_code = http_status.value
         self.response.reason = http_status.phrase
 
     def send_header(self, header: str, value: str) -> None:
         """Add the response header to the headers buffer."""
-        assert self.response is not None
+        assert self.response is not None  # nosec
         self.response.headers.append((header, value))
 
     def end_response(self, bytesdata: bytes) -> None:
         """Combines adding a length header and actually sending the data."""
-        assert self.response is not None
+        assert self.response is not None  # nosec
         self.response.body = bytesdata
 
     def dispatch(
@@ -466,7 +466,7 @@ class HAPServerHandler:
             HAP_TLV_TAGS.ENCRYPTED_DATA,
             aead_message,
         )
-        assert self.response is not None
+        assert self.response is not None  # nosec
         self.response.pairing_changed = True
         self._send_tlv_pairing_response(tlv_data)
 
@@ -598,7 +598,7 @@ class HAPServerHandler:
 
         data = tlv.encode(HAP_TLV_TAGS.SEQUENCE_NUM, HAP_TLV_STATES.M4)
         self._send_tlv_pairing_response(data)
-        assert self.response is not None
+        assert self.response is not None  # nosec
         self.response.shared_key = self.enc_context["shared_key"]
         self.is_encrypted = True
         self.client_uuid = client_uuid
@@ -620,7 +620,7 @@ class HAPServerHandler:
             raise UnprivilegedRequestException
 
         # Check that char exists and ...
-        assert self.parsed_url is not None
+        assert self.parsed_url is not None  # nosec
         params = parse_qs(self.parsed_url.query)
         response = self.accessory_handler.get_characteristics(
             params["id"][0].split(",")
@@ -649,7 +649,7 @@ class HAPServerHandler:
             self.send_response(HTTPStatus.UNAUTHORIZED)
             return
 
-        assert self.request_body is not None
+        assert self.request_body is not None  # nosec
         requested_chars = from_hap_json(self.request_body.decode("utf-8"))
         logger.debug(
             "%s: Set characteristics content: %s", self.client_address, requested_chars
@@ -686,7 +686,7 @@ class HAPServerHandler:
     def handle_pairings(self) -> None:
         """Handles a client request to update or remove a pairing."""
         # Must be an admin to handle pairings
-        assert self.client_uuid is not None
+        assert self.client_uuid is not None  # nosec
         if not self.is_encrypted or not self.state.is_admin(self.client_uuid):
             self._send_authentication_error_tlv_response(HAP_TLV_STATES.M2)
             return

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -749,7 +749,7 @@ class HAPServerHandler:
                     # or it will unpair the accessory because it thinks
                     # the username is invalid. We try to send back the
                     # exact bytes that was used to pair if we have it
-                    state.uuid_to_binary.get(client_uuid)
+                    state.uuid_to_bytes.get(client_uuid)
                     or str(client_uuid).encode("utf-8").upper(),
                     HAP_TLV_TAGS.PUBLIC_KEY,
                     client_public,

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -751,7 +751,7 @@ class HAPServerHandler:
             # client is removed, otherwise the controller
             # may not remove them all
             logger.debug("%s: updating mdns to unpaired", self.client_address)
-            assert self.response is not None
+            assert self.response is not None  # nosec
             self.response.pairing_changed = True
 
     def _handle_list_pairings(self) -> None:
@@ -799,7 +799,7 @@ class HAPServerHandler:
 
     def handle_resource(self) -> None:
         """Get a snapshot from the camera."""
-        assert self.request_body is not None
+        assert self.request_body is not None  # nosec
         data = from_hap_json(self.request_body.decode("utf-8"))
 
         if self.accessory_handler.accessory.category == CATEGORY_BRIDGE:
@@ -823,5 +823,5 @@ class HAPServerHandler:
         task = asyncio.ensure_future(asyncio.wait_for(coro, RESPONSE_TIMEOUT))
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", "image/jpeg")
-        assert self.response is not None
+        assert self.response is not None  # nosec
         self.response.task = task

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -559,9 +559,10 @@ class HAPServerHandler:
         perm_client_public = self.state.paired_clients.get(client_uuid)
         if perm_client_public is None:
             logger.error(
-                "%s: Client %s attempted pair verify without being paired to %s first.",
+                "%s: Client %s with uuid %s attempted pair verify without being paired first (paired clients=%s).",
                 self.client_address,
                 client_uuid,
+                self.state.paired_clients,
                 self.accessory_handler.accessory.display_name,
             )
             self._send_authentication_error_tlv_response(HAP_TLV_STATES.M4)

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -8,13 +8,12 @@ import logging
 from urllib.parse import parse_qs, urlparse
 import uuid
 
+from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 from cryptography.exceptions import InvalidSignature, InvalidTag
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
-from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 
 from pyhap import tlv
-
 from pyhap.const import (
     CATEGORY_BRIDGE,
     HAP_PERMISSIONS,
@@ -24,8 +23,10 @@ from pyhap.const import (
 )
 from pyhap.util import long_to_bytes
 
+from .accessory_driver import AccessoryDriver
 from .hap_crypto import hap_hkdf, pad_tls_nonce
-from .util import to_hap_json, from_hap_json
+from .state import State
+from .util import from_hap_json, to_hap_json
 
 # iOS will terminate the connection if it does not respond within
 # 10 seconds, so we only allow 9 seconds to avoid this.
@@ -129,13 +130,13 @@ class HAPServerHandler:
 
     PVERIFY_2_NONCE = pad_tls_nonce(b"PV-Msg03")
 
-    def __init__(self, accessory_handler, client_address):
+    def __init__(self, accessory_handler: AccessoryDriver, client_address):
         """
         @param accessory_handler: An object that controls an accessory's state.
         @type accessory_handler: AccessoryDriver
         """
-        self.accessory_handler = accessory_handler
-        self.state = self.accessory_handler.state
+        self.accessory_handler: AccessoryDriver = accessory_handler
+        self.state: State = self.accessory_handler.state
         self.enc_context = None
         self.client_address = client_address
         self.is_encrypted = False
@@ -343,13 +344,21 @@ class HAPServerHandler:
             return
 
         dec_tlv_objects = tlv.decode(bytes(decrypted_data))
-        client_username = dec_tlv_objects[HAP_TLV_TAGS.USERNAME]
+        client_username_bytes = dec_tlv_objects[HAP_TLV_TAGS.USERNAME]
         client_ltpk = dec_tlv_objects[HAP_TLV_TAGS.PUBLIC_KEY]
         client_proof = dec_tlv_objects[HAP_TLV_TAGS.PROOF]
 
-        self._pairing_four(client_username, client_ltpk, client_proof, hkdf_enc_key)
+        self._pairing_four(
+            client_username_bytes, client_ltpk, client_proof, hkdf_enc_key
+        )
 
-    def _pairing_four(self, client_username, client_ltpk, client_proof, encryption_key):
+    def _pairing_four(
+        self,
+        client_username_bytes: bytes,
+        client_ltpk: bytes,
+        client_proof: bytes,
+        encryption_key: bytes,
+    ):
         """Expand the SRP session key to obtain a new key.
             Use it to verify that the client's proof of the private key. Continue to
             step five.
@@ -372,7 +381,7 @@ class HAPServerHandler:
             long_to_bytes(session_key), self.PAIRING_4_SALT, self.PAIRING_4_INFO
         )
 
-        data = output_key + client_username + client_ltpk
+        data = output_key + client_username_bytes + client_ltpk
         verifying_key = ed25519.Ed25519PublicKey.from_public_bytes(client_ltpk)
 
         try:
@@ -381,9 +390,11 @@ class HAPServerHandler:
             logger.error("Bad signature, abort.")
             raise
 
-        self._pairing_five(client_username, client_ltpk, encryption_key)
+        self._pairing_five(client_username_bytes, client_ltpk, encryption_key)
 
-    def _pairing_five(self, client_username, client_ltpk, encryption_key):
+    def _pairing_five(
+        self, client_username_bytes: bytes, client_ltpk: bytes, encryption_key: bytes
+    ):
         """At that point we know the client has the accessory password and has a valid key
         pair. Add it as a pair and send a sever proof.
 
@@ -673,20 +684,17 @@ class HAPServerHandler:
 
     def _handle_add_pairing(self, tlv_objects):
         """Update client information."""
-        client_username = tlv_objects[HAP_TLV_TAGS.USERNAME]
-        client_username_str = str(client_username, "utf-8")
+        client_username_bytes = tlv_objects[HAP_TLV_TAGS.USERNAME]
         client_public = tlv_objects[HAP_TLV_TAGS.PUBLIC_KEY]
         permissions = tlv_objects[HAP_TLV_TAGS.PERMISSIONS]
-        client_uuid = uuid.UUID(client_username_str)
         logger.debug(
-            "%s: Adding client pairing for %s uuid=%s with permissions %s.",
+            "%s: Adding client pairing for %s with permissions %s.",
             self.client_address,
-            client_username_str,
-            client_uuid,
+            client_username_bytes,
             permissions,
         )
         should_confirm = self.accessory_handler.pair(
-            client_uuid, client_public, permissions
+            client_username_bytes, client_public, permissions
         )
         if not should_confirm:
             self._send_authentication_error_tlv_response(HAP_TLV_STATES.M2)
@@ -697,8 +705,8 @@ class HAPServerHandler:
 
     def _handle_remove_pairing(self, tlv_objects):
         """Remove pairing with the client."""
-        client_username = tlv_objects[HAP_TLV_TAGS.USERNAME]
-        client_username_str = str(client_username, "utf-8")
+        client_username_bytes: bytes = tlv_objects[HAP_TLV_TAGS.USERNAME]
+        client_username_str = client_username_bytes.decode("utf-8")
         client_uuid = uuid.UUID(client_username_str)
         was_paired = self.state.paired
         logger.debug(
@@ -727,15 +735,18 @@ class HAPServerHandler:
         """List current pairings."""
         logger.debug("%s: list pairings", self.client_address)
         response = [HAP_TLV_TAGS.SEQUENCE_NUM, HAP_TLV_STATES.M2]
-        for client_uuid, client_public in self.state.paired_clients.items():
+        state = self.state
+        for client_uuid, client_public in state.paired_clients.items():
             admin = self.state.is_admin(client_uuid)
             response.extend(
                 [
                     HAP_TLV_TAGS.USERNAME,
                     # iOS 16+ requires the username to be uppercase
                     # or it will unpair the accessory because it thinks
-                    # the username is invalid
-                    str(client_uuid).encode("utf-8").upper(),
+                    # the username is invalid. We try to send back the
+                    # exact bytes that was used to pair if we have it
+                    state.uuid_to_binary.get(client_uuid)
+                    or str(client_uuid).encode("utf-8").upper(),
                     HAP_TLV_TAGS.PUBLIC_KEY,
                     client_public,
                     HAP_TLV_TAGS.PERMISSIONS,

--- a/pyhap/hap_handler.py
+++ b/pyhap/hap_handler.py
@@ -5,6 +5,7 @@ The HAPServerHandler manages the state of the connection and handles incoming re
 import asyncio
 from http import HTTPStatus
 import logging
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 import uuid
 
@@ -23,10 +24,12 @@ from pyhap.const import (
 )
 from pyhap.util import long_to_bytes
 
-from .accessory_driver import AccessoryDriver
 from .hap_crypto import hap_hkdf, pad_tls_nonce
 from .state import State
 from .util import from_hap_json, to_hap_json
+
+if TYPE_CHECKING:
+    from .accessory_driver import AccessoryDriver
 
 # iOS will terminate the connection if it does not respond within
 # 10 seconds, so we only allow 9 seconds to avoid this.
@@ -130,7 +133,7 @@ class HAPServerHandler:
 
     PVERIFY_2_NONCE = pad_tls_nonce(b"PV-Msg03")
 
-    def __init__(self, accessory_handler: AccessoryDriver, client_address):
+    def __init__(self, accessory_handler, client_address):
         """
         @param accessory_handler: An object that controls an accessory's state.
         @type accessory_handler: AccessoryDriver
@@ -428,7 +431,7 @@ class HAPServerHandler:
         cipher = ChaCha20Poly1305(encryption_key)
         aead_message = bytes(cipher.encrypt(self.PAIRING_5_NONCE, bytes(message), b""))
 
-        client_username_str = str(client_username, "utf-8")
+        client_username_str = client_username_bytes.decode("utf-8")
         client_uuid = uuid.UUID(client_username_str)
         logger.debug(
             "Finishing pairing with admin %s uuid=%s", client_username_str, client_uuid

--- a/pyhap/state.py
+++ b/pyhap/state.py
@@ -1,4 +1,7 @@
 """Module for `State` class."""
+from typing import Dict
+from uuid import UUID
+
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from pyhap import util
@@ -35,34 +38,40 @@ class State:
 
         self.private_key = ed25519.Ed25519PrivateKey.generate()
         self.public_key = self.private_key.public_key()
+        self.uuid_to_binary: Dict[UUID, bytes] = {}
         self.accessories_hash = None
 
     # ### Pairing ###
     @property
-    def paired(self):
+    def paired(self) -> bool:
         """Return if main accessory is currently paired."""
         return len(self.paired_clients) > 0
 
-    def is_admin(self, client_uuid):
+    def is_admin(self, client_uuid: UUID) -> bool:
         """Check if a paired client is an admin."""
         if client_uuid not in self.client_properties:
             return False
         return bool(self.client_properties[client_uuid][CLIENT_PROP_PERMS] & ADMIN_BIT)
 
-    def add_paired_client(self, client_uuid, client_public, perms):
+    def add_paired_client(
+        self, client_username_bytes: bytes, client_public: bytes, perms: bytes
+    ) -> None:
         """Add a given client to dictionary of paired clients.
 
-        :param client_uuid: The client's UUID.
-        :type client_uuid: uuid.UUID
+        :param client_username_bytes: The client's user id bytes.
+        :type client_username_bytes: bytes
 
         :param client_public: The client's public key
             (not the session public key).
         :type client_public: bytes
         """
+        client_username_str = client_username_bytes.decode("utf-8")
+        client_uuid = UUID(client_username_str)
+        self.uuid_to_binary[client_uuid] = client_username_bytes
         self.paired_clients[client_uuid] = client_public
         self.client_properties[client_uuid] = {CLIENT_PROP_PERMS: ord(perms)}
 
-    def remove_paired_client(self, client_uuid):
+    def remove_paired_client(self, client_uuid: UUID) -> None:
         """Remove a given client from dictionary of paired clients.
 
         :param client_uuid: The client's UUID.
@@ -70,6 +79,7 @@ class State:
         """
         self.paired_clients.pop(client_uuid)
         self.client_properties.pop(client_uuid)
+        self.uuid_to_binary.pop(client_uuid, None)
 
         # All pairings must be removed when the last admin is removed
         if not any(self.is_admin(client_uuid) for client_uuid in self.paired_clients):

--- a/pyhap/state.py
+++ b/pyhap/state.py
@@ -38,7 +38,7 @@ class State:
 
         self.private_key = ed25519.Ed25519PrivateKey.generate()
         self.public_key = self.private_key.public_key()
-        self.uuid_to_binary: Dict[UUID, bytes] = {}
+        self.uuid_to_bytes: Dict[UUID, bytes] = {}
         self.accessories_hash = None
 
     # ### Pairing ###
@@ -67,7 +67,7 @@ class State:
         """
         client_username_str = client_username_bytes.decode("utf-8")
         client_uuid = UUID(client_username_str)
-        self.uuid_to_binary[client_uuid] = client_username_bytes
+        self.uuid_to_bytes[client_uuid] = client_username_bytes
         self.paired_clients[client_uuid] = client_public
         self.client_properties[client_uuid] = {CLIENT_PROP_PERMS: ord(perms)}
 
@@ -79,7 +79,7 @@ class State:
         """
         self.paired_clients.pop(client_uuid)
         self.client_properties.pop(client_uuid)
-        self.uuid_to_binary.pop(client_uuid, None)
+        self.uuid_to_bytes.pop(client_uuid, None)
 
         # All pairings must be removed when the last admin is removed
         if not any(self.is_admin(client_uuid) for client_uuid in self.paired_clients):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -21,8 +21,9 @@ def test_persist_and_load():
     sample_client_pk = _pk.public_key()
     state = State(mac=mac)
     admin_client_uuid = uuid.uuid1()
+    admin_client_bytes = str(admin_client_uuid).upper().encode("utf-8")
     state.add_paired_client(
-        admin_client_uuid,
+        admin_client_bytes,
         sample_client_pk.public_bytes(
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
@@ -31,8 +32,9 @@ def test_persist_and_load():
     )
     assert state.is_admin(admin_client_uuid)
     user_client_uuid = uuid.uuid1()
+    user_client_bytes = str(user_client_uuid).upper().encode("utf-8")
     state.add_paired_client(
-        user_client_uuid,
+        user_client_bytes,
         sample_client_pk.public_bytes(
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
@@ -77,8 +79,9 @@ def test_migration_to_include_client_properties():
     sample_client_pk = _pk.public_key()
     state = State(mac=mac)
     admin_client_uuid = uuid.uuid1()
+    admin_client_bytes = str(admin_client_uuid).upper().encode("utf-8")
     state.add_paired_client(
-        admin_client_uuid,
+        admin_client_bytes,
         sample_client_pk.public_bytes(
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
@@ -87,8 +90,9 @@ def test_migration_to_include_client_properties():
     )
     assert state.is_admin(admin_client_uuid)
     user_client_uuid = uuid.uuid1()
+    user_client_bytes = str(user_client_uuid).upper().encode("utf-8")
     state.add_paired_client(
-        user_client_uuid,
+        user_client_bytes,
         sample_client_pk.public_bytes(
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -12,9 +12,11 @@ from pyhap import hap_handler, tlv
 from pyhap.accessory import Accessory, Bridge
 from pyhap.characteristic import CharacteristicError
 from pyhap.const import HAP_PERMISSIONS
-
+from pyhap.accessory_driver import AccessoryDriver
 CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
+CLIENT_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
 CLIENT2_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c2")
+CLIENT2_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
 
 PUBLIC_KEY = b"\x99\x98d%\x8c\xf6h\x06\xfa\x85\x9f\x90\x82\xf2\xe8\x18\x9f\xf8\xc75\x1f>~\xc32\xc1OC\x13\xbfH\xad"
 
@@ -26,13 +28,13 @@ def test_response():
     assert "500" in str(response)
 
 
-def test_list_pairings_unencrypted(driver):
+def test_list_pairings_unencrypted(driver: AccessoryDriver):
     """Verify an unencrypted list pairings request fails."""
     driver.add_accessory(Accessory(driver, "TestAcc"))
 
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -57,7 +59,7 @@ def test_list_pairings(driver):
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = True
     handler.client_uuid = CLIENT_UUID
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -85,7 +87,7 @@ def test_add_pairing_admin(driver):
     handler.is_encrypted = True
     handler.client_uuid = CLIENT_UUID
     assert driver.state.paired is False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
 
     response = hap_handler.HAPResponse()
     handler.response = response
@@ -116,7 +118,7 @@ def test_add_pairing_user(driver):
     handler.is_encrypted = True
     handler.client_uuid = CLIENT_UUID
     assert driver.state.paired is False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
 
     response = hap_handler.HAPResponse()
     handler.response = response
@@ -189,8 +191,8 @@ def test_remove_pairing(driver):
     handler.is_encrypted = True
     handler.client_uuid = CLIENT_UUID
 
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
-    driver.pair(CLIENT2_UUID, PUBLIC_KEY, HAP_PERMISSIONS.USER)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT2_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.USER)
 
     assert driver.state.paired is True
     assert CLIENT_UUID in driver.state.paired_clients
@@ -240,7 +242,7 @@ def test_non_admin_pairings_request(driver):
     handler.is_encrypted = True
     handler.client_uuid = CLIENT_UUID
 
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.USER)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.USER)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -264,7 +266,7 @@ def test_invalid_pairings_request(driver):
     handler.is_encrypted = True
     handler.client_uuid = CLIENT_UUID
 
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -283,7 +285,7 @@ def test_pair_verify_one(driver):
 
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -335,7 +337,7 @@ def test_pair_verify_two_invaild_state(driver):
 
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -379,7 +381,7 @@ def test_invalid_pairing_request(driver):
 
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 
     response = hap_handler.HAPResponse()
@@ -666,7 +668,7 @@ def test_attempt_to_pair_when_already_paired(driver):
 
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = False
-    driver.pair(CLIENT_UUID, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
+    driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
 
     response = hap_handler.HAPResponse()
     handler.response = response

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -13,10 +13,11 @@ from pyhap.accessory import Accessory, Bridge
 from pyhap.characteristic import CharacteristicError
 from pyhap.const import HAP_PERMISSIONS
 from pyhap.accessory_driver import AccessoryDriver
+
 CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
 CLIENT_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
 CLIENT2_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c2")
-CLIENT2_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
+CLIENT2_UUID_BYTES = str(CLIENT2_UUID).upper().encode("utf-8")
 
 PUBLIC_KEY = b"\x99\x98d%\x8c\xf6h\x06\xfa\x85\x9f\x90\x82\xf2\xe8\x18\x9f\xf8\xc75\x1f>~\xc32\xc1OC\x13\xbfH\xad"
 

--- a/tests/test_hap_handler.py
+++ b/tests/test_hap_handler.py
@@ -35,6 +35,7 @@ def test_list_pairings_unencrypted(driver: AccessoryDriver):
 
     handler = hap_handler.HAPServerHandler(driver, "peername")
     handler.is_encrypted = False
+    handler.client_uuid = CLIENT_UUID
     driver.pair(CLIENT_UUID_BYTES, PUBLIC_KEY, HAP_PERMISSIONS.ADMIN)
     assert CLIENT_UUID in driver.state.paired_clients
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,9 +1,10 @@
 """Test for pyhap.state."""
 from unittest.mock import patch
+from uuid import UUID
 
 from cryptography.hazmat.primitives.asymmetric import ed25519
 import pytest
-from uuid import UUID
+
 from pyhap.const import CLIENT_PROP_PERMS, HAP_PERMISSIONS
 from pyhap.state import State
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -10,7 +10,7 @@ from pyhap.state import State
 CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
 CLIENT_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
 CLIENT2_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c2")
-CLIENT2_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
+CLIENT2_UUID_BYTES = str(CLIENT2_UUID).upper().encode("utf-8")
 
 
 def test_setup():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,9 +3,14 @@ from unittest.mock import patch
 
 from cryptography.hazmat.primitives.asymmetric import ed25519
 import pytest
-
+from uuid import UUID
 from pyhap.const import CLIENT_PROP_PERMS, HAP_PERMISSIONS
 from pyhap.state import State
+
+CLIENT_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c1")
+CLIENT_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
+CLIENT2_UUID = UUID("7d0d1ee9-46fe-4a56-a115-69df3f6860c2")
+CLIENT2_UUID_BYTES = str(CLIENT_UUID).upper().encode("utf-8")
 
 
 def test_setup():
@@ -28,7 +33,6 @@ def test_setup():
         "cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey.generate",
         return_value=private_key,
     ) as mock_create_keypair:
-
         state = State(address=addr, mac=mac, pincode=pin, port=port)
         assert not mock_local_addr.called
         assert not mock_gen_mac.called
@@ -59,21 +63,25 @@ def test_pairing_remove_last_admin():
     assert not state.paired
     assert not state.paired_clients
 
-    state.add_paired_client("uuid", "public", HAP_PERMISSIONS.ADMIN)
+    state.add_paired_client(CLIENT_UUID_BYTES, "public", HAP_PERMISSIONS.ADMIN)
     assert state.paired
-    assert state.paired_clients == {"uuid": "public"}
-    assert state.client_properties == {"uuid": {CLIENT_PROP_PERMS: 1}}
+    assert state.paired_clients == {CLIENT_UUID: "public"}
+    assert state.client_properties == {CLIENT_UUID: {CLIENT_PROP_PERMS: 1}}
 
-    state.add_paired_client("uuid2", "public", HAP_PERMISSIONS.USER)
+    state.add_paired_client(CLIENT2_UUID_BYTES, "public", HAP_PERMISSIONS.USER)
     assert state.paired
-    assert state.paired_clients == {"uuid": "public", "uuid2": "public"}
+    assert state.paired_clients == {CLIENT_UUID: "public", CLIENT2_UUID: "public"}
     assert state.client_properties == {
-        "uuid": {CLIENT_PROP_PERMS: 1},
-        "uuid2": {CLIENT_PROP_PERMS: 0},
+        CLIENT_UUID: {CLIENT_PROP_PERMS: 1},
+        CLIENT2_UUID: {CLIENT_PROP_PERMS: 0},
+    }
+    assert state.uuid_to_binary == {
+        CLIENT_UUID: CLIENT_UUID_BYTES,
+        CLIENT2_UUID: CLIENT2_UUID_BYTES,
     }
 
     # Removing the last admin should remove all non-admins
-    state.remove_paired_client("uuid")
+    state.remove_paired_client(CLIENT_UUID)
     assert not state.paired
     assert not state.paired_clients
 
@@ -88,22 +96,22 @@ def test_pairing_two_admins():
     assert not state.paired
     assert not state.paired_clients
 
-    state.add_paired_client("uuid", "public", HAP_PERMISSIONS.ADMIN)
+    state.add_paired_client(CLIENT_UUID_BYTES, "public", HAP_PERMISSIONS.ADMIN)
     assert state.paired
-    assert state.paired_clients == {"uuid": "public"}
-    assert state.client_properties == {"uuid": {CLIENT_PROP_PERMS: 1}}
+    assert state.paired_clients == {CLIENT_UUID: "public"}
+    assert state.client_properties == {CLIENT_UUID: {CLIENT_PROP_PERMS: 1}}
 
-    state.add_paired_client("uuid2", "public", HAP_PERMISSIONS.ADMIN)
+    state.add_paired_client(CLIENT2_UUID_BYTES, "public", HAP_PERMISSIONS.ADMIN)
     assert state.paired
-    assert state.paired_clients == {"uuid": "public", "uuid2": "public"}
+    assert state.paired_clients == {CLIENT_UUID: "public", CLIENT2_UUID: "public"}
     assert state.client_properties == {
-        "uuid": {CLIENT_PROP_PERMS: 1},
-        "uuid2": {CLIENT_PROP_PERMS: 1},
+        CLIENT_UUID: {CLIENT_PROP_PERMS: 1},
+        CLIENT2_UUID: {CLIENT_PROP_PERMS: 1},
     }
 
     # Removing the admin should leave the other admin
-    state.remove_paired_client("uuid2")
+    state.remove_paired_client(CLIENT2_UUID)
     assert state.paired
-    assert state.paired_clients == {"uuid": "public"}
-    assert state.client_properties == {"uuid": {CLIENT_PROP_PERMS: 1}}
-    assert not state.is_admin("uuid2")
+    assert state.paired_clients == {CLIENT_UUID: "public"}
+    assert state.client_properties == {CLIENT_UUID: {CLIENT_PROP_PERMS: 1}}
+    assert not state.is_admin(CLIENT2_UUID)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -76,7 +76,7 @@ def test_pairing_remove_last_admin():
         CLIENT_UUID: {CLIENT_PROP_PERMS: 1},
         CLIENT2_UUID: {CLIENT_PROP_PERMS: 0},
     }
-    assert state.uuid_to_binary == {
+    assert state.uuid_to_bytes == {
         CLIENT_UUID: CLIENT_UUID_BYTES,
         CLIENT2_UUID: CLIENT2_UUID_BYTES,
     }

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
 commands =
     make clean
     sphinx-build -W -b html source {envtmpdir}/html
-whitelist_externals=
+allowlist_externals=
     /usr/bin/make
     make
 
@@ -47,6 +47,7 @@ whitelist_externals=
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}
 deps =
+    -r{toxinidir}/requirements_all.txt
     -r{toxinidir}/requirements_test.txt
 commands =
     flake8 pyhap tests --ignore=D10,D205,D4,E501,E126,E128,W504,W503,E203


### PR DESCRIPTION
apple seems to keep changing the case on these so we will now keep the binary blob and send back the exact bytes that was used in pairing when the client list pairings.

This should fix the users having trouble after migrating to the new home arch