### PR TITLE
Add services and characteristics used by Home Keys

### DIFF
--- a/pyhap/resources/characteristics.json
+++ b/pyhap/resources/characteristics.json
@@ -1664,5 +1664,36 @@
       "maxValue": 100,
       "minValue": 0,
       "unit": "percentage"
+   },
+   "HardwareFinish": {
+      "Format": "tlv8",
+      "Permissions": [
+         "pr"
+      ],
+      "UUID": "0000026C-0000-1000-8000-0026BB765291"
+   },
+   "ConfigurationState": {
+      "Format": "uint16",
+      "Permissions": [
+         "pr",
+         "ev"
+      ],
+      "UUID": "00000263-0000-1000-8000-0026BB765291"
+   },
+   "NFCAccessControlPoint": {
+      "Format": "tlv8",
+      "Permissions": [
+         "pr",
+         "pw",
+         "wr"
+      ],
+      "UUID": "00000264-0000-1000-8000-0026BB765291"
+   },
+   "NFCAccessSupportedConfiguration": {
+      "Format": "tlv8",
+      "Permissions": [
+         "pr"
+      ],
+      "UUID": "00000265-0000-1000-8000-0026BB765291"
    }
 }

--- a/pyhap/resources/services.json
+++ b/pyhap/resources/services.json
@@ -2,7 +2,8 @@
    "AccessoryInformation": {
       "OptionalCharacteristics": [
          "HardwareRevision",
-         "AccessoryFlags"
+         "AccessoryFlags",
+         "HardwareFinish"
       ],
       "RequiredCharacteristics": [
          "Identify",
@@ -576,5 +577,14 @@
          "PositionState"
       ],
       "UUID": "0000008C-0000-1000-8000-0026BB765291"
+   },
+   "NFCAccess": {
+      "OptionalCharacteristics": [],
+      "RequiredCharacteristics": [
+         "ConfigurationState",
+         "NFCAccessControlPoint",
+         "NFCAccessSupportedConfiguration"
+      ],
+      "UUID": "00000266-0000-1000-8000-0026BB765291"
    }
 }


### PR DESCRIPTION
This pull request adds following services and characteristics into the `characteristics.json` and `services.json` files:

- AccessoryInformation (Existing):
   * HardwareFinish:   used to retrieve hardware finish (color, material) in order to draw home key pass in a matching color.

- NFCAccess:
   * ConfigurationState
   * NFCAccessSupportedConfiguration: used to retrieve amount of keys that a lock can store.
   * NFCAccessControlPoint: used to configure keys: write/read/delete device/reader keys, etc.

Information about those services had been taken from:
- [@KhaosT - HAP-NodeJS](https://github.com/KhaosT/HAP-NodeJS/commit/80cdb1535f5bee874cc06657ef283ee91f258815);
- [@kupa22 - Apple Home Key](https://github.com/kupa22/apple-homekey)