### PR TITLE
Refactor set_characteristics

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -888,7 +888,8 @@ class AccessoryDriver:
             if HAP_REPR_VALUE not in query and not expired:
                 continue
 
-            aid, iid = query[HAP_REPR_AID], query[HAP_REPR_IID]
+            aid = query[HAP_REPR_AID]
+            iid = query[HAP_REPR_IID]
             value = query.get(HAP_REPR_VALUE)
             write_response_requested = query.get(HAP_REPR_WRITE_RESPONSE, False)
 

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 import threading
 import time
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from zeroconf import ServiceInfo
 from zeroconf.asyncio import AsyncZeroconf

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -879,9 +879,11 @@ class AccessoryDriver:
         updates_by_accessories_services = {}
         char_to_iid = {}
 
+        expired = False
         pid = chars_query.get(HAP_REPR_PID, None)
-        expire_time = self.prepared_writes.get(client_addr, {}).pop(pid, None)
-        expired = False if pid is None else expire_time is None or time.time() > expire_time
+        if pid is not None:
+            expire_time = self.prepared_writes.get(client_addr, {}).pop(pid, None)
+            expired = expire_time is None or time.time() > expire_time
 
         to_update = (query for query in queries if HAP_REPR_VALUE in query or expired)
         for query in to_update:

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -35,7 +35,6 @@ from zeroconf.asyncio import AsyncZeroconf
 from pyhap import util
 from pyhap.accessory import Accessory, get_topic
 from pyhap.characteristic import Characteristic, CharacteristicError
-from pyhap.service import Service
 from pyhap.const import (
     HAP_PERMISSION_NOTIFY,
     HAP_PROTOCOL_SHORT_VERSION,
@@ -55,6 +54,7 @@ from pyhap.hap_server import HAPServer
 from pyhap.hsrp import Server as SrpServer
 from pyhap.loader import Loader
 from pyhap.params import get_srp_context
+from pyhap.service import Service
 from pyhap.state import State
 
 from .const import HAP_SERVER_STATUS
@@ -997,8 +997,10 @@ class AccessoryDriver:
             logger.error("Could not stop AccessoryDriver because of error: %s", e)
             raise
 
-    def _notify(self, queries: List[Dict[str, Any]], client_addr: Tuple[str, int]) -> None:
-        """Notify the driver that the client has subscribed or unsubscribed."""    
+    def _notify(
+        self, queries: List[Dict[str, Any]], client_addr: Tuple[str, int]
+    ) -> None:
+        """Notify the driver that the client has subscribed or unsubscribed."""
         for query in queries:
             if HAP_PERMISSION_NOTIFY not in query:
                 continue

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -922,7 +922,7 @@ class AccessoryDriver:
                 updates_by_accessories_services[acc] = {}
             if service not in updates_by_accessories_services[acc]:
                 updates_by_accessories_services[acc][service] = {}
-            updates_by_accessories_services[acc][service].update({char: value})
+            updates_by_accessories_services[acc][service][char] = value
 
         # Proccess accessory and service level setter callbacks
         for acc, updates_by_service in updates_by_accessories_services.items():

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 import threading
 import time
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
 from zeroconf import ServiceInfo
 from zeroconf.asyncio import AsyncZeroconf

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -997,7 +997,7 @@ class AccessoryDriver:
             logger.error("Could not stop AccessoryDriver because of error: %s", e)
             raise
 
-    def _notify(self, queries, client_addr):
+    def _notify(self, queries: List[Dict[str, Any]], client_addr: Tuple[str, int]) -> None:
         for query in queries:
             if HAP_PERMISSION_NOTIFY not in query:
                 continue

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -998,6 +998,7 @@ class AccessoryDriver:
             raise
 
     def _notify(self, queries: List[Dict[str, Any]], client_addr: Tuple[str, int]) -> None:
+        """Notify the driver that the client has subscribed or unsubscribed."""    
         for query in queries:
             if HAP_PERMISSION_NOTIFY not in query:
                 continue

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -920,7 +920,7 @@ class AccessoryDriver:
                 set_result = _wrap_acc_setter(acc, updates_by_service, client_addr)
 
                 characteristics = (
-                    char for chars in updates_by_accessories_services[acc].values()
+                    char for chars in updates_by_service.values()
                     for char in chars.keys()
                 )
                 for char in characteristics:

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -866,13 +866,13 @@ class AccessoryDriver:
 
         self._notify(queries, client_addr)
 
-        updates_by_accessories_services = defaultdict(lambda: defaultdict(lambda: {}))
-        results = defaultdict(lambda: defaultdict(lambda: {}))
+        updates_by_accessories_services = defaultdict(lambda: defaultdict(dict))
+        results = defaultdict(lambda: defaultdict(dict))
         char_to_iid = {}
 
         expired = False
-        pid = chars_query.get(HAP_REPR_PID, None)
-        if pid is not None:
+        if HAP_REPR_PID in chars_query:
+            pid = chars_query[HAP_REPR_PID]
             expire_time = self.prepared_writes.get(client_addr, {}).pop(pid, None)
             expired = expire_time is None or time.time() > expire_time
 

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -34,7 +34,7 @@ from zeroconf.asyncio import AsyncZeroconf
 
 from pyhap import util
 from pyhap.accessory import Accessory, get_topic
-from pyhap.characteristic import CharacteristicError, Characteristic
+from pyhap.characteristic import Characteristic, CharacteristicError
 from pyhap.service import Service
 from pyhap.const import (
     HAP_PERMISSION_NOTIFY,

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -870,7 +870,7 @@ class AccessoryDriver:
         updates_by_accessories_services: Dict[
             Accessory, Dict[Service, Dict[Characteristic, Any]]
         ] = defaultdict(lambda: defaultdict(dict))
-        results: Dict[int, Dict[int, dict[str, Any]]] = defaultdict(
+        results: Dict[int, Dict[int, Dict[str, Any]]] = defaultdict(
             lambda: defaultdict(dict)
         )
         char_to_iid: Dict[Characteristic, int] = {}

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -867,10 +867,10 @@ class AccessoryDriver:
 
         self._notify(queries, client_addr)
 
-        updates_by_accessories_services: defaultdict[
-            Accessory, defaultdict[Service, dict[Characteristic, Any]]
+        updates_by_accessories_services: Dict[
+            Accessory, Dict[Service, Dict[Characteristic, Any]]
         ] = defaultdict(lambda: defaultdict(dict))
-        results: defaultdict[int, defaultdict[int, dict[str, Any]]] = defaultdict(
+        results: Dict[int, Dict[int, dict[str, Any]]] = defaultdict(
             lambda: defaultdict(dict)
         )
         char_to_iid: Dict[Characteristic, int] = {}

--- a/tests/test_accessory_driver.py
+++ b/tests/test_accessory_driver.py
@@ -177,16 +177,7 @@ def test_write_response_returned_when_not_requested(driver: AccessoryDriver):
         },
         "mock_addr",
     )
-    assert response == {
-        HAP_REPR_CHARS: [
-            {
-                HAP_REPR_AID: acc.aid,
-                HAP_REPR_IID: char_nfc_access_control_point_iid,
-                HAP_REPR_STATUS: 0,
-                HAP_REPR_VALUE: 1
-            },
-        ]
-    }
+    assert response is None
 
     response = driver.set_characteristics(
         {
@@ -200,16 +191,7 @@ def test_write_response_returned_when_not_requested(driver: AccessoryDriver):
         },
         "mock_addr",
     )
-    assert response == {
-        HAP_REPR_CHARS: [
-            {
-                HAP_REPR_AID: acc.aid,
-                HAP_REPR_IID: char_nfc_access_control_point_iid,
-                HAP_REPR_STATUS: 0,
-                HAP_REPR_VALUE: 1
-            },
-        ]
-    }
+    assert response is None
 
 
 def test_write_response_returned_when_requested(driver: AccessoryDriver):


### PR DESCRIPTION
This commit aims at refactoring set_characteristics method, particularly by doing the following
1. Unwrapping multi-layer nested loops into comprehensions and/or single layer loops where possible.
2. Removing as much (if/else) branching as possible
3. Removing (dict) mutations and redundant variables where possible
4. Trying to separate discrete operations into separate loops (for notifications, query setters, accessory + service callbacks)

Some of the changes to the code required modifying 2 tests created by me for write responses, as new behaviour makes it so that no write response value is returned if it wasn't requested, even if callback returned one. This is actually better than before, because this way if someone's legacy code returns a value from a setter by accident, it won't be sent in a response if there was no request for it.

New code seems to pass all other existing unit tests, but lack of regressions definitely has to be verified separately.
If any other changes to the code need to be made (perhaps code style or something else), I am ready to cooperate.