### PR TITLE
Fix handling of explict close

### DIFF
--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -241,7 +241,9 @@ class Accessory:
         """
         return {
             HAP_REPR_AID: self.aid,
-            HAP_REPR_SERVICES: [s.to_HAP(include_value=include_value) for s in self.services],
+            HAP_REPR_SERVICES: [
+                s.to_HAP(include_value=include_value) for s in self.services
+            ],
         }
 
     def setup_message(self):
@@ -391,7 +393,10 @@ class Bridge(Accessory):
 
         .. seealso:: Accessory.to_HAP
         """
-        return [acc.to_HAP(include_value=include_value) for acc in (super(), *self.accessories.values())]
+        return [
+            acc.to_HAP(include_value=include_value)
+            for acc in (super(), *self.accessories.values())
+        ]
 
     def get_characteristic(self, aid: int, iid: int) -> Optional["Characteristic"]:
         """.. seealso:: Accessory.to_HAP"""

--- a/pyhap/hap_server.py
+++ b/pyhap/hap_server.py
@@ -3,11 +3,16 @@
 The HAPServer is the point of contact to and from the world.
 """
 
+import asyncio
 import logging
 import time
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 from .hap_protocol import HAPServerProtocol
 from .util import callback
+
+if TYPE_CHECKING:
+    from .accessory_driver import AccessoryDriver
 
 logger = logging.getLogger(__name__)
 
@@ -28,17 +33,18 @@ class HAPServer:
     implements exclusive access to the send methods.
     """
 
-    def __init__(self, addr_port, accessory_handler):
+    def __init__(
+        self, addr_port: Tuple[str, int], accessory_handler: "AccessoryDriver"
+    ) -> None:
         """Create a HAP Server."""
         self._addr_port = addr_port
-        self.connections = {}  # (address, port): socket
+        self.connections: Dict[Tuple[str, int], HAPServerProtocol] = {}
         self.accessory_handler = accessory_handler
-        self.server = None
-        self._serve_task = None
-        self._connection_cleanup = None
-        self.loop = None
+        self.server: Optional[asyncio.Server] = None
+        self._connection_cleanup: Optional[asyncio.TimerHandle] = None
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
 
-    async def async_start(self, loop):
+    async def async_start(self, loop: asyncio.AbstractEventLoop) -> None:
         """Start the http-hap server."""
         self.loop = loop
         self.server = await loop.create_server(
@@ -49,7 +55,7 @@ class HAPServer:
         self.async_cleanup_connections()
 
     @callback
-    def async_cleanup_connections(self):
+    def async_cleanup_connections(self) -> None:
         """Cleanup stale connections."""
         now = time.time()
         for hap_proto in list(self.connections.values()):
@@ -59,7 +65,7 @@ class HAPServer:
         )
 
     @callback
-    def async_stop(self):
+    def async_stop(self) -> None:
         """Stop the server.
 
         This method must be run in the event loop.
@@ -70,10 +76,12 @@ class HAPServer:
         self.server.close()
         self.connections.clear()
 
-    def push_event(self, data, client_addr, immediate=False):
+    def push_event(
+        self, data: bytes, client_addr: Tuple[str, int], immediate: bool = False
+    ) -> bool:
         """Queue an event to the current connection with the provided data.
 
-        :param data: The charateristic changes
+        :param data: The characteristic changes
         :type data: dict
 
         :param client_addr: A client (address, port) tuple to which to send the data.


### PR DESCRIPTION
The check for next_event was not correct for explict closes as https://github.com/python-hyper/h11/blob/a2c68948accadc3876dffcf979d98002e4a4ed27/h11/_connection.py#L445

will only return h11.ConnectionClosed as an object and not a type