### PR TITLE
Late-import base36 and QR code libraries; remove SUPPORT_QR_CODE flag

### DIFF
--- a/pyhap/__init__.py
+++ b/pyhap/__init__.py
@@ -5,15 +5,3 @@ RESOURCE_DIR = os.path.join(ROOT, "resources")
 
 CHARACTERISTICS_FILE = os.path.join(RESOURCE_DIR, "characteristics.json")
 SERVICES_FILE = os.path.join(RESOURCE_DIR, "services.json")
-
-
-# Flag if QR Code dependencies are installed.
-# Installation with `pip install HAP-python[QRCode]`.
-SUPPORT_QR_CODE = False
-try:
-    import base36  # noqa: F401
-    import pyqrcode  # noqa: F401
-
-    SUPPORT_QR_CODE = True
-except ImportError:
-    pass

--- a/pyhap/accessory.py
+++ b/pyhap/accessory.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 from uuid import UUID
 
-from . import SUPPORT_QR_CODE, util
+from . import util
 from .const import (
     CATEGORY_BRIDGE,
     CATEGORY_OTHER,
@@ -17,10 +17,6 @@ from .const import (
 )
 from .iid_manager import IIDManager
 from .service import Service
-
-if SUPPORT_QR_CODE:
-    import base36
-    from pyqrcode import QRCode
 
 
 if TYPE_CHECKING:
@@ -190,6 +186,12 @@ class Accessory:
 
         :rtype: str
         """
+        try:
+            import base36
+        except ImportError as ie:
+            raise RuntimeError(
+                "The base36 module is required to generate X-HM:// URIs"
+            ) from ie
         payload = 0
         payload |= 0 & 0x7  # version
 
@@ -253,7 +255,15 @@ class Accessory:
         Installation through `pip install HAP-python[QRCode]`
         """
         pincode = self.driver.state.pincode.decode()
-        if SUPPORT_QR_CODE:
+        try:
+            from qrcode import QRCode
+        except ImportError:
+            print(
+                "To use the QR Code feature, use 'pip install HAP-python[QRCode]'\n"
+                f"Enter this code in your HomeKit app on your iOS device: {pincode}",
+                flush=True,
+            )
+        else:
             xhm_uri = self.xhm_uri()
             print(f"Setup payload: {xhm_uri}", flush=True)
             print(
@@ -262,15 +272,6 @@ class Accessory:
             print(QRCode(xhm_uri).terminal(quiet_zone=2), flush=True)
             print(
                 f"Or enter this code in your HomeKit app on your iOS device: {pincode}",
-                flush=True,
-            )
-        else:
-            print(
-                "To use the QR Code feature, use 'pip install HAP-python[QRCode]'",
-                flush=True,
-            )
-            print(
-                f"Enter this code in your HomeKit app on your iOS device: {pincode}",
                 flush=True,
             )
 


### PR DESCRIPTION
Some tests run locally for `home-assistant/core` would fail with a cryptic "base36 is not defined" error if that library was not installed.

This PR:

* makes that error message cleaner – it's now a `RuntimeError` that has the import error as a reason
* makes `pyhap` not import `base36` or `QRCode` at all until they are needed 
  * in doing that removes the `SUPPORT_QR_CODE` flag; based on [GitHub Code Search](https://github.com/search?q=SUPPORT_QR_CODE+language%3APython&type=code&l=Python) there are no external users for that flag that I can see.