### PR TITLE
Implement zerocopy writes for the encrypted protocol

### DIFF
--- a/pyhap/hap_crypto.py
+++ b/pyhap/hap_crypto.py
@@ -3,7 +3,7 @@ from functools import partial
 import logging
 import struct
 from struct import Struct
-from typing import List
+from typing import Iterable, List
 
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 from cryptography.hazmat.backends import default_backend
@@ -112,7 +112,7 @@ class HAPCrypto:
 
         return result
 
-    def encrypt(self, data: bytes) -> bytes:
+    def encrypt(self, data: bytes) -> Iterable[bytes]:
         """Encrypt and send the return bytes."""
         result: List[bytes] = []
         offset = 0
@@ -127,7 +127,4 @@ class HAPCrypto:
             offset += length
             self._out_count += 1
 
-        # Join the result once instead of concatenating each time
-        # as this is much faster than generating an new immutable
-        # byte string each time.
-        return b"".join(result)
+        return result

--- a/pyhap/hap_protocol.py
+++ b/pyhap/hap_protocol.py
@@ -104,7 +104,7 @@ class HAPServerProtocol(asyncio.Protocol):
                 self.handler.client_uuid,
                 data,
             )
-            self.transport.write(result)
+            self.transport.writelines(result)
         else:
             logger.debug(
                 "%s (%s): Send unencrypted: %s",

--- a/tests/test_hap_crypto.py
+++ b/tests/test_hap_crypto.py
@@ -15,7 +15,7 @@ def test_round_trip():
     crypto.OUT_CIPHER_INFO = crypto.IN_CIPHER_INFO
     crypto.reset(key)
 
-    encrypted = bytearray(crypto.encrypt(plaintext))
+    encrypted = bytearray(b"".join(crypto.encrypt(plaintext)))
 
     # Receive no data
     assert crypto.decrypt() == b""


### PR DESCRIPTION
With Python 3.12+ and later `transport.writelines` is implemented as [`sendmsg(..., IOV_MAX)`](https://github.com/python/cpython/issues/91166) which allows us to avoid joining the bytes and sending them in one go.

Older Python will effectively do the same thing we do now `b"".join(...)`