### PR TITLE
Address remaining pylint complaints

### DIFF
--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -323,7 +323,7 @@ class AccessoryDriver:
                 and os.name != "nt"
             ):
                 logger.debug("Setting child watcher")
-                watcher = asyncio.SafeChildWatcher()
+                watcher = asyncio.SafeChildWatcher() # pylint: disable=deprecated-class
                 watcher.attach_loop(self.loop)
                 asyncio.set_child_watcher(watcher)
             else:

--- a/pyhap/accessory_driver.py
+++ b/pyhap/accessory_driver.py
@@ -653,7 +653,8 @@ class AccessoryDriver:
                 os.name == "nt"
             ):  # Or `[WinError 5] Access Denied` will be raised on Windows
                 os.chmod(tmp_filename, 0o644)
-                os.path.exists(self.persist_file) and os.chmod(self.persist_file, 0o644)
+                if os.path.exists(self.persist_file):
+                    os.chmod(self.persist_file, 0o644)
             os.replace(tmp_filename, self.persist_file)
         except Exception:  # pylint: disable=broad-except
             logger.exception("Failed to persist accessory state")

--- a/tox.ini
+++ b/tox.ini
@@ -61,8 +61,8 @@ deps =
     -r{toxinidir}/requirements_all.txt
     -r{toxinidir}/requirements_test.txt
 commands =
-    pylint pyhap --disable=missing-docstring,empty-docstring,invalid-name,fixme --max-line-length=120
-    pylint tests --disable=duplicate-code,missing-docstring,empty-docstring,invalid-name,fixme --max-line-length=120
+    pylint pyhap --disable=missing-docstring,empty-docstring,invalid-name,fixme,too-many-positional-arguments --max-line-length=120
+    pylint tests --disable=duplicate-code,missing-docstring,empty-docstring,invalid-name,fixme,too-many-positional-arguments --max-line-length=120
 
 
 [testenv:bandit]


### PR DESCRIPTION
Note that CI will still fail because codecov now requires an upload token.  We end up hard coding them in ` .codecov.yml` for most repos now ex https://github.com/aio-libs/yarl/blob/dfc41dbfcd5a91283ab6c5c21d70bc4b1c377789/.codecov.yml#L10