### PR TITLE
Use SPDX license expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     project_urls=PROJECT_URLS,
     python_requires=">={}".format(MIN_PY_VERSION),
     install_requires=REQUIRES,
-    license="Apache License 2.0",
+    license="Apache-2.0",
     license_file="LICENSE",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Use SPDX license expression as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/Apache-2.0.html