### PR TITLE
Replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/pyhap/util.py
+++ b/pyhap/util.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import functools
+import inspect
 import random
 import socket
 import sys
@@ -41,7 +42,7 @@ def iscoro(func):
     """
     if isinstance(func, functools.partial):
         func = func.func
-    return asyncio.iscoroutinefunction(func)
+    return inspect.iscoroutinefunction(func)
 
 
 def get_local_address() -> str:


### PR DESCRIPTION
Python 3.14 will deprecated `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` which has been available for some time now.

https://docs.python.org/3.14/deprecations/pending-removal-in-3.16.html
https://docs.python.org/3.14/library/inspect.html#inspect.iscoroutinefunction