### PR TITLE
Add AirPlayEnable characteristic + service for SmartSpeakers

### DIFF
--- a/pyhap/resources/characteristics.json
+++ b/pyhap/resources/characteristics.json
@@ -72,6 +72,17 @@
          "2.5\u03bcm": 0
       }
    },
+   "AirPlayEnable": {
+      "Format": "uint8",
+      "Permissions": [
+         "pr",
+         "pw",
+         "ev"
+      ],
+      "UUID": "0000025B-0000-1000-8000-0026BB765291",
+      "maxValue": 1,
+      "minValue": 0
+   },
    "AirQuality": {
       "Format": "uint8",
       "Permissions": [

--- a/pyhap/resources/services.json
+++ b/pyhap/resources/services.json
@@ -428,6 +428,20 @@
       ],
       "UUID": "000000B9-0000-1000-8000-0026BB765291"
    },
+   "SmartSpeaker": {
+      "OptionalCharacteristics": [
+         "Name",
+         "ConfiguredName",
+         "AirPlayEnable",
+         "Volume",
+         "Mute"
+      ],
+      "RequiredCharacteristics": [
+         "CurrentMediaState",
+         "TargetMediaState"
+      ],
+      "UUID": "00000228-0000-1000-8000-0026BB765291"
+   },
    "SmokeSensor": {
       "OptionalCharacteristics": [
          "StatusActive",


### PR DESCRIPTION
Two changes:

1. Adds `AirPlayEnable` characteristic
2. Adds `SmartSpeaker` service

This is in prep for a PR against HA core to address the "group of switches" issues referenced in #275 and in home-assistant/core#157319

Should be consistent with the definitions in HAP-NodeJS:
 
* [`AirPlayEnable`](https://github.com/homebridge/HAP-NodeJS/blob/latest/src/lib/definitions/CharacteristicDefinitions.ts#L219-L236)
* [`SmartSpeaker`](https://github.com/homebridge/HAP-NodeJS/blob/latest/src/lib/definitions/ServiceDefinitions.ts#L1143-L1165)