### PR TITLE
Add support for camera talkback (two-way) audio

### DIFF
--- a/pyhap/camera.py
+++ b/pyhap/camera.py
@@ -27,6 +27,7 @@ from uuid import UUID
 
 from pyhap import RESOURCE_DIR, tlv
 from pyhap.accessory import Accessory
+from pyhap.camera_talkback import TalkbackReceiver, talkback_available
 from pyhap.const import CATEGORY_CAMERA
 from pyhap.util import byte_bool, to_base64_str
 
@@ -427,6 +428,13 @@ class Camera(Accessory):
 
             Additional optional values are:
             - srtp - boolean, defaults to False. Whether the camera supports SRTP.
+            - talkback - boolean, defaults to False. Whether the camera supports
+                receiving two-way ("talkback") audio from the controller during a
+                live view session. Requires the optional ``pylibsrtp`` dependency
+                (``pip install HAP-python[Talkback]``). When enabled, a "Speaker"
+                service is added so that HAP clients know the accessory supports
+                it, and :meth:`talkback_audio_received` is called with the
+                received audio for each session that negotiates it.
             - start_stream_cmd - string specifying the command to be executed to start
                 the stream. The string can contain the keywords, corresponding to the
                 video and audio configuration that was negotiated between the camera
@@ -435,6 +443,12 @@ class Camera(Accessory):
         :type options: ``dict``
         """
         self.has_srtp = options.get("srtp", False)
+        self.support_talkback = options.get("talkback", False)
+        if self.support_talkback and not talkback_available():
+            raise ValueError(
+                "The 'talkback' option requires the optional 'pylibsrtp' "
+                "dependency. Install it with: pip install HAP-python[Talkback]"
+            )
         self.start_stream_cmd = options.get("start_stream_cmd", FFMPEG_CMD)
 
         self.stream_address = options["address"]
@@ -448,6 +462,8 @@ class Camera(Accessory):
         super().__init__(*args, **kwargs)
 
         self.add_preload_service("Microphone")
+        if self.support_talkback:
+            self.add_preload_service("Speaker").configure_char("Mute", value=False)
         self._streaming_status = []
         self._management = []
         self._setup_stream_management(options)
@@ -625,6 +641,7 @@ class Camera(Accessory):
             logger.error(
                 "[%s] Failed to start/reconfigure stream, deleting session.", session_id
             )
+            self._close_talkback(session_info)
             del self.sessions[session_id]
             self._streaming_status[stream_idx] = STREAMING_STATUS["AVAILABLE"]
 
@@ -657,9 +674,48 @@ class Camera(Accessory):
 
         stream_idx = session_info["stream_idx"]
         await self.stop_stream(session_info)
+        self._close_talkback(session_info)
         del self.sessions[session_id]
 
         self._streaming_status[stream_idx] = STREAMING_STATUS["AVAILABLE"]
+
+    @staticmethod
+    def _close_talkback(session_info):
+        """Stop the talkback audio receiver for a session, if any."""
+        audio_backchannel = session_info.pop("audio_backchannel", None)
+        if audio_backchannel is not None:
+            audio_backchannel.stop()
+
+    def _talkback_payload_received(self, session_id, payload: bytes) -> None:
+        """Dispatch a received talkback RTP payload to the accessory implementation.
+
+        Called from the :class:`~pyhap.camera_talkback.TalkbackReceiver`
+        background thread, so this hops back onto the accessory driver's event
+        loop before calling the (synchronous) public callback, to keep
+        :meth:`talkback_audio_received` easy to implement without every caller
+        having to worry about thread-safety.
+        """
+        self.driver.loop.call_soon_threadsafe(
+            self.talkback_audio_received, session_id, payload
+        )
+
+    def talkback_audio_received(
+        self, session_id, payload: bytes
+    ) -> None:  # pylint: disable=unused-argument
+        """Handle received two-way ("talkback") audio for a streaming session.
+
+        Only called for sessions of accessories constructed with the
+        ``talkback`` option enabled (see ``__init__``). Override to consume the
+        received audio, e.g. decode it (the codec is whichever was negotiated,
+        see ``a_codec`` in the stream configuration passed to
+        :meth:`start_stream`) and play it out through a speaker.
+
+        :param session_id: The session ID this audio belongs to.
+        :type session_id: :class:`~uuid.UUID`
+        :param payload: The RTP payload of one received packet, still encoded
+            with the negotiated audio codec (not decoded by pyhap).
+        :type payload: ``bytes``
+        """
 
     def set_selected_stream_configuration(self, value):
         """Set the selected stream configuration.
@@ -787,6 +843,27 @@ class Camera(Accessory):
         video_ssrc = int.from_bytes(os.urandom(3), byteorder="big")
         audio_ssrc = int.from_bytes(os.urandom(3), byteorder="big")
 
+        # If talkback is enabled, open a local receiver for the audio the
+        # controller will send back during the session, and report *its* real
+        # port below instead of echoing the controller's own port back at it.
+        # Per the HAP spec (section 11, "IP Cameras"), the "Accessory Address"
+        # TLV in this response carries the accessory's own address/ports (the
+        # "Controller Address" received above carries the controller's), so
+        # echoing the controller's port here left HAP clients with nowhere
+        # valid to send the talkback audio to.
+        audio_backchannel = None
+        audio_rtp_port = target_audio_port
+        if self.support_talkback:
+            audio_backchannel = TalkbackReceiver(
+                srtp_key_and_salt=audio_master_key + audio_master_salt,
+                on_payload=functools.partial(
+                    self._talkback_payload_received, session_id
+                ),
+                is_ipv6=bool(is_ipv6),
+            )
+            audio_backchannel.start()
+            audio_rtp_port = audio_backchannel.local_port
+
         res_address_tlv = tlv.encode(
             SETUP_ADDR_INFO["ADDRESS_VER"],
             self.stream_address_isv6,
@@ -795,7 +872,7 @@ class Camera(Accessory):
             SETUP_ADDR_INFO["VIDEO_RTP_PORT"],
             struct.pack("<H", target_video_port),
             SETUP_ADDR_INFO["AUDIO_RTP_PORT"],
-            struct.pack("<H", target_audio_port),
+            struct.pack("<H", audio_rtp_port),
         )
 
         response_tlv = tlv.encode(
@@ -826,6 +903,7 @@ class Camera(Accessory):
             "a_port": target_audio_port,
             "a_srtp_key": to_base64_str(audio_master_key + audio_master_salt),
             "a_ssrc": audio_ssrc,
+            "audio_backchannel": audio_backchannel,
         }
 
         self._management[stream_idx].get_characteristic("SetupEndpoints").set_value(

--- a/pyhap/camera_talkback.py
+++ b/pyhap/camera_talkback.py
@@ -1,0 +1,176 @@
+"""Support for the HomeKit camera audio talkback (two-way audio) channel.
+
+The HomeKit Accessory Protocol Specification (section 11 "IP Cameras") requires
+that, for a camera to support two-way audio, the accessory reports a local port
+where it listens for the audio the controller (e.g. the iOS Home app) sends back
+during a live view session ("Accessory Address" in the SetupEndpoints response,
+Table 9-16 of the spec). Prior to this module, :mod:`pyhap.camera` echoed back the
+*controller's* address in that field instead of a real local listening port,
+which meant no HAP camera accessory built with this library could ever receive
+the talkback audio: the controller had nowhere to send it.
+
+This module implements the receiving side of that channel: a UDP socket bound to
+an OS-assigned local port, SRTP decryption using the same key already negotiated
+by :meth:`pyhap.camera.Camera.set_endpoints`, and RTP depacketization. The
+decoded-from-RTP payload (still encoded with whichever audio codec was
+negotiated, typically Opus) is handed to a callback for the accessory
+implementation to decode/consume as it sees fit -- this mirrors how
+:meth:`pyhap.camera.Camera.start_stream` already leaves video/audio encoding of
+the *outgoing* stream to the implementation (or ffmpeg) rather than pyhap
+itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import socket
+import struct
+import threading
+from typing import Callable
+
+try:
+    import pylibsrtp
+except ImportError:  # pragma: no cover - exercised via requires_talkback()
+    pylibsrtp = None
+
+logger = logging.getLogger(__name__)
+
+RTP_HEADER_LEN = 12
+
+
+def talkback_available() -> bool:
+    """Whether the optional dependency for talkback support is installed."""
+    return pylibsrtp is not None
+
+
+@dataclass
+class RtpPacket:
+    """A parsed RTP packet (RFC 3550), payload still codec-encoded."""
+
+    version: int
+    padding: bool
+    marker: bool
+    payload_type: int
+    sequence_number: int
+    timestamp: int
+    ssrc: int
+    payload: bytes
+
+
+def parse_rtp_packet(packet: bytes) -> RtpPacket:
+    """Parse the RTP header of an already SRTP-decrypted packet."""
+    if len(packet) < RTP_HEADER_LEN:
+        raise ValueError(f"Packet too short to be RTP: {len(packet)} bytes")
+
+    b0, b1, seq, timestamp, ssrc = struct.unpack("!BBHII", packet[:12])
+    version = b0 >> 6
+    padding = bool((b0 >> 5) & 1)
+    extension = (b0 >> 4) & 1
+    csrc_count = b0 & 0x0F
+    marker = bool(b1 >> 7)
+    payload_type = b1 & 0x7F
+
+    offset = RTP_HEADER_LEN + csrc_count * 4
+    if extension:
+        if len(packet) < offset + 4:
+            raise ValueError("Truncated RTP extension header")
+        ext_len_words = struct.unpack("!H", packet[offset + 2 : offset + 4])[0]
+        offset += 4 + ext_len_words * 4
+
+    if padding and packet:
+        pad_len = packet[-1]
+        payload = packet[offset : len(packet) - pad_len]
+    else:
+        payload = packet[offset:]
+
+    return RtpPacket(
+        version=version,
+        padding=padding,
+        marker=marker,
+        payload_type=payload_type,
+        sequence_number=seq,
+        timestamp=timestamp,
+        ssrc=ssrc,
+        payload=payload,
+    )
+
+
+class TalkbackReceiver:
+    """Listens for the HomeKit camera talkback (two-way) audio of one session.
+
+    :param srtp_key_and_salt: The audio SRTP master key concatenated with the
+        master salt, exactly as already negotiated in
+        :meth:`pyhap.camera.Camera.set_endpoints` (``audio_master_key +
+        audio_master_salt``). Reused here, not renegotiated.
+    :param on_payload: Called from a background thread with the RTP payload
+        (``bytes``) of each received packet, still encoded with whichever audio
+        codec was negotiated for the session (see ``a_codec`` in the stream
+        configuration passed to :meth:`pyhap.camera.Camera.start_stream`).
+    :param is_ipv6: Whether to bind an IPv6 socket instead of IPv4.
+    """
+
+    def __init__(
+        self,
+        srtp_key_and_salt: bytes,
+        on_payload: Callable[[bytes], None],
+        is_ipv6: bool = False,
+    ) -> None:
+        if pylibsrtp is None:
+            raise RuntimeError(
+                "Talkback support requires the 'pylibsrtp' package. "
+                "Install it with: pip install HAP-python[Talkback]"
+            )
+
+        policy = pylibsrtp.Policy(
+            key=srtp_key_and_salt,
+            ssrc_type=pylibsrtp.Policy.SSRC_ANY_INBOUND,
+        )
+        self._session = pylibsrtp.Session(policy)
+        self._on_payload = on_payload
+
+        family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
+        self._sock = socket.socket(family, socket.SOCK_DGRAM)
+        self._sock.bind(("::" if is_ipv6 else "0.0.0.0", 0))
+        self._sock.settimeout(0.5)
+
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name="hap-camera-talkback", daemon=True
+        )
+
+    @property
+    def local_port(self) -> int:
+        """The local port this receiver is bound to.
+
+        This is the value that must be reported in the ``AUDIO_RTP_PORT`` field
+        of the ``Accessory Address`` TLV in the ``SetupEndpoints`` response, so
+        that the controller knows where to send the talkback audio.
+        """
+        return self._sock.getsockname()[1]
+
+    def start(self) -> None:
+        """Start listening for incoming audio in a background thread."""
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop listening and release the socket."""
+        self._stop_event.set()
+        self._thread.join(timeout=2)
+        self._sock.close()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                data, _addr = self._sock.recvfrom(2048)
+            except TimeoutError:
+                continue
+            except OSError:
+                break
+            try:
+                rtp_plain = self._session.unprotect(data)
+                packet = parse_rtp_packet(rtp_plain)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("Failed to process incoming talkback audio packet")
+                continue
+            self._on_payload(packet.payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ QRCode = [
     "base36",
     "pyqrcode",
 ]
+Talkback = [
+    "pylibsrtp",
+]
 
 [project.urls]
 "Source" = "https://github.com/ikalchev/HAP-python"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ def mock_local_address():
 class MockDriver:
     def __init__(self):
         self.loader = Loader()
+        self.loop = None
 
     def publish(self, data, client_addr=None, immediate=False):
         pass

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,9 +1,14 @@
 """Tests for pyhap.camera."""
 
+import asyncio
+import socket
+import struct
 from unittest.mock import Mock, patch
 from uuid import UUID
 
-from pyhap import camera
+import pytest
+
+from pyhap import camera, tlv
 
 _OPTIONS = {
     "stream_count": 4,
@@ -143,3 +148,153 @@ def test_set_selected_stream_start_stop(mock_driver):
     assert session_id not in acc.sessions
     assert process_mock.terminate.called
     assert acc.streaming_status == camera.STREAMING_STATUS["AVAILABLE"]
+
+
+def test_no_talkback_by_default(mock_driver):
+    """Without the ``talkback`` option, no Speaker service is added and
+    SetupEndpoints keeps echoing the controller's port back (unchanged,
+    pre-existing behavior for accessories that don't opt in)."""
+    set_endpoint_req = (
+        "ARCszGzBBWNFFY2pdLRQkAaRAxoBAQACDTE5Mi4xNjguMS4xMTQDAjPFBAKs1gQ"
+        "lAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QEBAAUlAhAKRPSRVa"
+        "qGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQEBAA=="
+    )
+
+    acc = camera.Camera(_OPTIONS, mock_driver, "Camera")
+    assert acc.get_service("Speaker") is None
+
+    setup_endpoints = acc.get_service("CameraRTPStreamManagement").get_characteristic(
+        "SetupEndpoints"
+    )
+    setup_endpoints.client_update_value(set_endpoint_req)
+
+    session_id = list(acc.sessions)[0]
+    assert acc.sessions[session_id]["audio_backchannel"] is None
+
+
+def _controller_audio_port(request_b64: str) -> int:
+    """Extract the controller's requested audio port from a SetupEndpoints
+    write value, for comparison against the accessory's response."""
+    objs = tlv.decode(request_b64, from_base64=True)
+    address_objs = tlv.decode(objs[camera.SETUP_TYPES["ADDRESS"]])
+    return struct.unpack("<H", address_objs[camera.SETUP_ADDR_INFO["AUDIO_RTP_PORT"]])[
+        0
+    ]
+
+
+def _accessory_audio_port(response_b64: str) -> int:
+    """Extract the accessory's reported audio port from a SetupEndpoints
+    response value."""
+    objs = tlv.decode(response_b64, from_base64=True)
+    address_objs = tlv.decode(objs[camera.SETUP_TYPES["ADDRESS"]])
+    return struct.unpack("<H", address_objs[camera.SETUP_ADDR_INFO["AUDIO_RTP_PORT"]])[
+        0
+    ]
+
+
+def _audio_srtp_key_and_salt(request_b64: str) -> bytes:
+    """Extract the audio SRTP master key + salt from a SetupEndpoints write
+    value, exactly as the accessory itself would when negotiating the
+    session."""
+    objs = tlv.decode(request_b64, from_base64=True)
+    audio_srtp_objs = tlv.decode(objs[camera.SETUP_TYPES["AUDIO_SRTP_PARAM"]])
+    return (
+        audio_srtp_objs[camera.SETUP_SRTP_PARAM["MASTER_KEY"]]
+        + audio_srtp_objs[camera.SETUP_SRTP_PARAM["MASTER_SALT"]]
+    )
+
+
+def test_talkback_enabled_adds_speaker_service(mock_driver):
+    """With ``talkback=True``, a muted-by-default Speaker service is added so
+    that HAP clients know the accessory supports receiving two-way audio."""
+    options = dict(_OPTIONS, talkback=True)
+    acc = camera.Camera(options, mock_driver, "Camera")
+
+    speaker = acc.get_service("Speaker")
+    assert speaker is not None
+    assert speaker.get_characteristic("Mute").get_value() is False
+
+
+def test_setup_endpoints_reports_real_port_when_talkback_enabled(mock_driver):
+    """The accessory must report a real local listening port for the audio
+    talkback channel, not echo the controller's own port back at it (the bug
+    this module fixes: HAP clients had nowhere valid to send the talkback
+    audio to, because the accessory never actually listened anywhere)."""
+    set_endpoint_req = (
+        "ARCszGzBBWNFFY2pdLRQkAaRAxoBAQACDTE5Mi4xNjguMS4xMTQDAjPFBAKs1gQ"
+        "lAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QEBAAUlAhAKRPSRVa"
+        "qGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQEBAA=="
+    )
+
+    options = dict(_OPTIONS, talkback=True)
+    acc = camera.Camera(options, mock_driver, "Camera")
+    setup_endpoints = acc.get_service("CameraRTPStreamManagement").get_characteristic(
+        "SetupEndpoints"
+    )
+    setup_endpoints.client_update_value(set_endpoint_req)
+
+    session_id = list(acc.sessions)[0]
+    receiver = acc.sessions[session_id]["audio_backchannel"]
+    assert receiver is not None
+
+    reported_port = _accessory_audio_port(setup_endpoints.get_value())
+    assert reported_port == receiver.local_port
+    assert reported_port != _controller_audio_port(set_endpoint_req)
+
+    receiver.stop()
+
+
+@pytest.mark.asyncio
+async def test_talkback_audio_is_received_and_dispatched(mock_driver):
+    """End-to-end: an SRTP audio packet sent to the reported port (as a HAP
+    client would during a live view session) is decrypted, RTP-parsed, and
+    dispatched to ``talkback_audio_received`` with the raw codec payload."""
+    pylibsrtp = pytest.importorskip("pylibsrtp")
+
+    mock_driver.loop = asyncio.get_running_loop()
+
+    received = []
+
+    class TalkbackCamera(camera.Camera):
+        def talkback_audio_received(self, session_id, payload):
+            received.append((session_id, payload))
+
+    set_endpoint_req = (
+        "ARCszGzBBWNFFY2pdLRQkAaRAxoBAQACDTE5Mi4xNjguMS4xMTQDAjPFBAKs1gQ"
+        "lAhDYlmCkyTBZQfxqFS3OnxVOAw4bQZm5NuoQjyanlqWA0QEBAAUlAhAKRPSRVa"
+        "qGeNmESTIojxNiAw78WkjTLtGv0waWnLo9gQEBAA=="
+    )
+
+    options = dict(_OPTIONS, talkback=True)
+    acc = TalkbackCamera(options, mock_driver, "Camera")
+    setup_endpoints = acc.get_service("CameraRTPStreamManagement").get_characteristic(
+        "SetupEndpoints"
+    )
+    setup_endpoints.client_update_value(set_endpoint_req)
+
+    session_id = list(acc.sessions)[0]
+    receiver = acc.sessions[session_id]["audio_backchannel"]
+    port = receiver.local_port
+
+    key_and_salt = _audio_srtp_key_and_salt(set_endpoint_req)
+    rtp_payload = b"opus-frame-payload"
+    rtp_packet = struct.pack("!BBHII", 0x80, 110, 1, 0, 0x1234) + rtp_payload
+
+    sender_session = pylibsrtp.Session(
+        pylibsrtp.Policy(key=key_and_salt, ssrc_type=pylibsrtp.Policy.SSRC_ANY_OUTBOUND)
+    )
+    srtp_packet = sender_session.protect(rtp_packet)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.sendto(srtp_packet, ("127.0.0.1", port))
+
+        for _ in range(100):
+            if received:
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        sock.close()
+        receiver.stop()
+
+    assert received == [(session_id, rtp_payload)]


### PR DESCRIPTION
# Add support for camera talkback (two-way) audio

Fixes #446

## The problem

`SetupEndpoints` currently echoes the *controller's* own audio port back in
the `Accessory Address` TLV of its response, instead of reporting a real
local port the accessory listens on:

```python
res_address_tlv = tlv.encode(
    ...
    SETUP_ADDR_INFO["AUDIO_RTP_PORT"], struct.pack("<H", target_audio_port),
)
```

Per the HAP spec (section 11, "IP Cameras" — the `Accessory Address` field of
the `SetupEndpoints` response, distinct from the `Controller Address` the
accessory receives in the request), this field is meant to tell the
controller where *it* should send the talkback audio during a live view
session. Because this library has always echoed the controller's own port
back at it instead, no Camera accessory built with HAP-python — regardless of
what the application code does — could ever receive that audio: the
controller had nowhere valid to send it.

This is a real, long-standing gap, not just a theoretical reading of the spec.
#446 describes exactly this symptom two years ago: *"I do see that my phone
sends an RTP stream back to HAP-python when the talk button is pressed but I
don't know how I can get the properties of that stream in advance, mainly
which port, codec and encryption is used."* — because the port it needs was
never a real one to begin with. It's also why two-way audio has never worked
in Home Assistant's HomeKit Bridge integration (which uses this library),
tracked there as an open feature request with no implementation in several
years either.

## The fix

An opt-in `talkback` option on `Camera.__init__`. When enabled:

- A `Speaker` service is added (mirroring the `Microphone` service this class
  already adds unconditionally), so HAP clients know the accessory supports
  receiving two-way audio and show the corresponding UI (e.g. the microphone
  button during a live view in the iOS Home app).
- `set_endpoints` opens a local UDP receiver (new `pyhap.camera_talkback`
  module) bound to an OS-assigned port, and reports *that* port in the
  response instead of echoing the controller's.
- The receiver decrypts incoming SRTP packets using the same key already
  negotiated earlier in the same `set_endpoints` call (not renegotiated), and
  parses the RTP framing.
- Each received packet's payload — still encoded with whichever audio codec
  was negotiated (typically Opus), decoding is intentionally left to the
  caller — is dispatched to a new overridable method:

  ```python
  def talkback_audio_received(self, session_id, payload: bytes) -> None:
      """Override to consume the received audio."""
  ```

Leaving codec decoding to the caller mirrors how `start_stream` already
leaves the *outgoing* video/audio pipeline (ffmpeg or otherwise) to the
implementation rather than pyhap. It also avoids adding a hard dependency on
an Opus decoder to this library for a codec choice the negotiation makes at
runtime (AAC-ELD is also possible per the spec).

The new `pylibsrtp` dependency is optional (`pip install
HAP-python[Talkback]`), only required when `talkback=True` is actually used.

## Backward compatibility

`talkback` defaults to `False`. With it disabled (the default, i.e. every
existing accessory), behavior is unchanged — verified by running the full
existing test suite unmodified: all pre-existing tests pass.

## Testing

- Added unit tests in `tests/test_camera.py`:
  - `talkback=True` adds a muted-by-default `Speaker` service.
  - `SetupEndpoints` reports a real, distinct local port when talkback is
    enabled (vs. the pre-existing echo behavior when it isn't).
  - An end-to-end test that builds a real SRTP-encrypted RTP packet (using
    the same key negotiated in the `SetupEndpoints` request), sends it over
    an actual UDP socket to the reported port, and asserts
    `talkback_audio_received` is called with the correct decrypted payload.
- Beyond the unit tests in this PR: this fix has been verified against a real
  iOS Home app and a real HomeKit pairing (not just synthetic packets in a
  test) via a Home Assistant custom component built on top of an earlier,
  in-tree version of this same fix. Logs from that session show a sustained,
  correctly-timed stream of decrypted/decoded audio packets while
  speaking into the Home app's microphone button during a live camera view.
  Happy to share more detail on that setup if useful for review.

## Notes for reviewers / open questions

- I called the option `talkback` — happy to rename if you'd prefer something
  else (`two_way_audio`, `support_talkback`, etc.)
- Payload delivery is raw/undecoded by design (see above) — flagging in case
  you'd rather this library also handled Opus decoding for the common case.
- `Camera._talkback_payload_received` hops onto `self.driver.loop` via
  `call_soon_threadsafe` before calling the public (synchronous)
  `talkback_audio_received`, since the receiver's socket loop runs in its own
  background thread. Let me know if you'd rather this be a coroutine
  (`await self.talkback_audio_received(...)`) instead of a plain callback —
  went with synchronous since most consumers will just want to hand the bytes
  off to a queue/pipe rather than do async work per-packet, but no strong
  opinion.
